### PR TITLE
[CLI-253] Prevent "Unrecognized option: --null" when handling long opts in PosixParser

### DIFF
--- a/src/main/java/org/apache/commons/cli/Options.java
+++ b/src/main/java/org/apache/commons/cli/Options.java
@@ -224,6 +224,20 @@ public class Options implements Serializable
     }
 
     /**
+     * Retrieve the {@link Option} matching the long name specified.
+     * The leading hyphens in the name are ignored (up to 2).
+     *
+     * @param opt long name of the {@link Option}
+     * @return the option represented by opt
+     */
+    Option getLongOption(String opt)
+    {
+        opt = Util.stripLeadingHyphens(opt);
+
+        return longOpts.get(opt);
+    }
+
+    /**
      * Returns the options with a long name starting with the name specified.
      * 
      * @param opt the partial name of the option

--- a/src/main/java/org/apache/commons/cli/PosixParser.java
+++ b/src/main/java/org/apache/commons/cli/PosixParser.java
@@ -131,7 +131,7 @@ public class PosixParser extends Parser
                 }
                 else
                 {
-                    currentOption = options.getOption(matchingOpts.get(0));
+                    currentOption = options.getLongOption(matchingOpts.get(0));
                     
                     tokens.add("--" + currentOption.getLongOpt());
                     if (pos != -1)

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI253Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI253Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.cli.bug;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.PosixParser;
+import org.junit.Test;
+
+@SuppressWarnings("deprecation") // tests some deprecated classes
+public class BugCLI253Test {
+
+    @Test
+    public void testGroovyUseCase() throws ParseException {
+        CommandLine cli = new PosixParser().parse(getOptions(), new String[] { "--classpath" });
+        assertTrue(cli.hasOption("--classpath"));
+    }
+
+    private Options getOptions() {
+        Options options = new Options();
+        options.addOption(Option.builder("classpath").build());
+        options.addOption(Option.builder("cp").longOpt("classpath").build());
+        return options;
+    }
+}


### PR DESCRIPTION
Attempt to fix [CLI-253](https://issues.apache.org/jira/browse/CLI-253).
