### PR TITLE
Removing unnecessary subclassing of DefaultParserTest

### DIFF
--- a/src/test/java/org/apache/commons/cli/bug/BugCLI252Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI252Test.java
@@ -20,7 +20,7 @@ package org.apache.commons.cli.bug;
 import org.apache.commons.cli.*;
 import org.junit.Test;
 
-public class BugCLI252Test extends DefaultParserTest {
+public class BugCLI252Test {
 
     @Test
     public void testExactOptionNameMatch() throws ParseException {


### PR DESCRIPTION
The test class BugCLI252Test extends DefaultParserTest, but there is no need for it to do so as it does not use anything from DefaultParserTest. Currently, with this inheritance, 58 tests from DefaultParserTest are run unnecessarily (as they are already run by DefaultParserTest). By removing the inheritance, 58 fewer tests need to be run when testing.