### PR TITLE
Skipping empty tests

### DIFF
--- a/src/test/java/org/apache/commons/cli/BasicParserTest.java
+++ b/src/test/java/org/apache/commons/cli/BasicParserTest.java
@@ -18,6 +18,8 @@
 package org.apache.commons.cli;
 
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class BasicParserTest extends ParserTestCase
@@ -29,145 +31,145 @@ public class BasicParserTest extends ParserTestCase
         parser = new BasicParser();
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testDoubleDash2() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testLongWithoutEqualSingleDash() throws Exception
     {
         // not supported by the BasicParser
     }
     
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception
     {
         // not supported by the basicParser
     }
     
-    @Override
+    @Override @Test @Ignore
     public void testNegativeOption() throws Exception
     {
         // not supported by the BasicParser (CLI-184)
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testPropertiesOption1() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testPropertiesOption2() throws Exception
     {
         // not supported by the BasicParser
     }    
 
-    @Override
+    @Override @Test @Ignore
     public void testShortWithEqual() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testShortWithoutEqual() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testLongWithEqualDoubleDash() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testLongWithEqualSingleDash() throws Exception
     {
         // not supported by the BasicParser
     }
     
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption1() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption2() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption3() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption4() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption1() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption2() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption3() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption4() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testPartialLongOptionSingleDash() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testBursting() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnrecognizedOptionWithBursting() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testMissingArgWithBursting() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testStopBursting() throws Exception
     {
         // not supported by the BasicParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testStopBursting2() throws Exception
     {
         // not supported by the BasicParser

--- a/src/test/java/org/apache/commons/cli/BasicParserTest.java
+++ b/src/test/java/org/apache/commons/cli/BasicParserTest.java
@@ -31,147 +31,123 @@ public class BasicParserTest extends ParserTestCase
         parser = new BasicParser();
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testDoubleDash2() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testLongWithoutEqualSingleDash() throws Exception
     {
-        // not supported by the BasicParser
     }
     
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception
     {
-        // not supported by the basicParser
     }
     
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser (CLI-184)")
     public void testNegativeOption() throws Exception
     {
-        // not supported by the BasicParser (CLI-184)
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testPropertiesOption1() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testPropertiesOption2() throws Exception
     {
-        // not supported by the BasicParser
     }    
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testShortWithEqual() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testShortWithoutEqual() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testLongWithEqualDoubleDash() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testLongWithEqualSingleDash() throws Exception
     {
-        // not supported by the BasicParser
     }
     
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testUnambiguousPartialLongOption1() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testUnambiguousPartialLongOption2() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testUnambiguousPartialLongOption3() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testUnambiguousPartialLongOption4() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testAmbiguousPartialLongOption1() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testAmbiguousPartialLongOption2() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testAmbiguousPartialLongOption3() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testAmbiguousPartialLongOption4() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testPartialLongOptionSingleDash() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testBursting() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testUnrecognizedOptionWithBursting() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testMissingArgWithBursting() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testStopBursting() throws Exception
     {
-        // not supported by the BasicParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the BasicParser")
     public void testStopBursting2() throws Exception
     {
-        // not supported by the BasicParser
     }
 }

--- a/src/test/java/org/apache/commons/cli/GnuParserTest.java
+++ b/src/test/java/org/apache/commons/cli/GnuParserTest.java
@@ -18,6 +18,8 @@
 package org.apache.commons.cli;
 
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class GnuParserTest extends ParserTestCase
@@ -29,127 +31,127 @@ public class GnuParserTest extends ParserTestCase
         parser = new GnuParser();
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testDoubleDash2() throws Exception
     {
         // not supported by the GnuParser
     }
     
-    @Override
+    @Override @Test @Ignore
     public void testLongWithoutEqualSingleDash() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testNegativeOption() throws Exception
     {
         // not supported by the GnuParser (CLI-184)
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testLongWithUnexpectedArgument1() throws Exception 
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testLongWithUnexpectedArgument2() throws Exception 
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testShortWithUnexpectedArgument() throws Exception 
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption1() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption2() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption3() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption4() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption1() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption2() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption3() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption4() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testPartialLongOptionSingleDash() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testBursting() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnrecognizedOptionWithBursting() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testMissingArgWithBursting() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testStopBursting() throws Exception
     {
         // not supported by the GnuParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testStopBursting2() throws Exception
     {
         // not supported by the GnuParser

--- a/src/test/java/org/apache/commons/cli/GnuParserTest.java
+++ b/src/test/java/org/apache/commons/cli/GnuParserTest.java
@@ -31,129 +31,108 @@ public class GnuParserTest extends ParserTestCase
         parser = new GnuParser();
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testDoubleDash2() throws Exception
     {
-        // not supported by the GnuParser
     }
     
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testLongWithoutEqualSingleDash() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser (CLI-184)")
     public void testNegativeOption() throws Exception
     {
-        // not supported by the GnuParser (CLI-184)
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testLongWithUnexpectedArgument1() throws Exception 
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testLongWithUnexpectedArgument2() throws Exception 
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testShortWithUnexpectedArgument() throws Exception 
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testUnambiguousPartialLongOption1() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testUnambiguousPartialLongOption2() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testUnambiguousPartialLongOption3() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testUnambiguousPartialLongOption4() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testAmbiguousPartialLongOption1() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testAmbiguousPartialLongOption2() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testAmbiguousPartialLongOption3() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testAmbiguousPartialLongOption4() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testPartialLongOptionSingleDash() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testBursting() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testUnrecognizedOptionWithBursting() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testMissingArgWithBursting() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testStopBursting() throws Exception
     {
-        // not supported by the GnuParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the GnuParser")
     public void testStopBursting2() throws Exception
     {
-        // not supported by the GnuParser
     }
 }

--- a/src/test/java/org/apache/commons/cli/PosixParserTest.java
+++ b/src/test/java/org/apache/commons/cli/PosixParserTest.java
@@ -18,6 +18,8 @@
 package org.apache.commons.cli;
 
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Test case for the PosixParser.
@@ -32,55 +34,55 @@ public class PosixParserTest extends ParserTestCase
         parser = new PosixParser();
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testDoubleDash2() throws Exception
     {
         // not supported by the PosixParser
     }
     
-    @Override
+    @Override @Test @Ignore
     public void testLongWithoutEqualSingleDash() throws Exception
     {
         // not supported by the PosixParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception
     {
         // not supported by the PosixParser
     }
     
-    @Override
+    @Override @Test @Ignore
     public void testNegativeOption() throws Exception
     {
         // not supported by the PosixParser (CLI-184)
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testLongWithUnexpectedArgument1() throws Exception
     {
         // not supported by the PosixParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testLongWithEqualSingleDash() throws Exception
     {
         // not supported by the PosixParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testShortWithEqual() throws Exception
     {
         // not supported by the PosixParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testUnambiguousPartialLongOption4() throws Exception
     {
         // not supported by the PosixParser
     }
 
-    @Override
+    @Override @Test @Ignore
     public void testAmbiguousPartialLongOption4() throws Exception
     {
         // not supported by the PosixParser

--- a/src/test/java/org/apache/commons/cli/PosixParserTest.java
+++ b/src/test/java/org/apache/commons/cli/PosixParserTest.java
@@ -34,57 +34,48 @@ public class PosixParserTest extends ParserTestCase
         parser = new PosixParser();
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser")
     public void testDoubleDash2() throws Exception
     {
-        // not supported by the PosixParser
     }
     
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser")
     public void testLongWithoutEqualSingleDash() throws Exception
     {
-        // not supported by the PosixParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser")
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception
     {
-        // not supported by the PosixParser
     }
     
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser (CLI-184)")
     public void testNegativeOption() throws Exception
     {
-        // not supported by the PosixParser (CLI-184)
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser")
     public void testLongWithUnexpectedArgument1() throws Exception
     {
-        // not supported by the PosixParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser")
     public void testLongWithEqualSingleDash() throws Exception
     {
-        // not supported by the PosixParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser")
     public void testShortWithEqual() throws Exception
     {
-        // not supported by the PosixParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser")
     public void testUnambiguousPartialLongOption4() throws Exception
     {
-        // not supported by the PosixParser
     }
 
-    @Override @Test @Ignore
+    @Override @Test @Ignore("not supported by the PosixParser")
     public void testAmbiguousPartialLongOption4() throws Exception
     {
-        // not supported by the PosixParser
     }
 }


### PR DESCRIPTION
This pull request adds @Ignore to tests with purposely left empty test bodies due to the features not being implemented (the @Test is added as well due to how JUnit processes annotations and would not actually skip these tests unless they are annotated with @Test). With these ignores, 54 test cases can be skipped from execution.