### PR TITLE
Add an addRequiredOption method

### DIFF
--- a/src/main/java/org/apache/commons/cli/Options.java
+++ b/src/main/java/org/apache/commons/cli/Options.java
@@ -143,6 +143,25 @@ public class Options implements Serializable
     }
 
     /**
+     * Add an option that contains a short-name and a long-name.
+     * This option is set as required.
+     * It may be specified as requiring an argument.
+     *
+     * @param opt Short single-character name of the option.
+     * @param longOpt Long multi-character name of the option.
+     * @param hasArg flag signally if an argument is required after this option
+     * @param description Self-documenting description
+     * @return the resulting Options instance
+     */
+    public Options addRequiredOption(String opt, String longOpt, boolean hasArg, String description)
+    {
+        Option option = new Option(opt, longOpt, hasArg, description);
+        option.setRequired(true);
+        addOption(option);
+        return this;
+    }
+
+    /**
      * Adds an option instance
      *
      * @param opt the option that is to be added


### PR DESCRIPTION
This pull request adds an addRequiredOption method, which creates an Option with setRequired(true).

This is really useful, given the amount of projects I saw doing things like:

```
Options options = new Options();
options.addOption( "a", "all", false, "do not hide entries starting with ." );
options.addOption( "A", "almost-all", false, "do not list implied . and .." );
options.addOption( "b", "escape", false, "print octal escapes for nongraphic " + "characters" );
// ... more addOptions like these and then
Option stuff = new Option( "c", "stuff", true, "do not list implied . and .." );
stuff.setRequired(true);
options.addOption( stuff );
// And many more required options like this one
```
This pull request proposes an auxiliary method to create a required option, so that these options could just be added with.

`options.addRequiredOption( "c", "stuff", true, "do not list implied . and .." );`