### PR TITLE
[CLI-274] implement EXISTING_FILE_VALUE type handler

### DIFF
--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -19,6 +19,7 @@ package org.apache.commons.cli;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -18,6 +18,7 @@
 package org.apache.commons.cli;
 
 import java.io.File;
+import java.io.FileInputStream;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -87,7 +88,7 @@ public class TypeHandler
         }
         else if (PatternOptionBuilder.EXISTING_FILE_VALUE == clazz)
         {
-            return createFile(str);
+            return openFile(str);
         }
         else if (PatternOptionBuilder.FILES_VALUE == clazz)
         {
@@ -220,6 +221,24 @@ public class TypeHandler
     public static File createFile(String str)
     {
         return new File(str);
+    }
+
+    /**
+     * Returns the opened FileInputStream represented by <code>str</code>.
+     *
+     * @param str the file location
+     * @return The file input stream represented by <code>str</code>.
+     */
+    public static FileInputStream openFile(String str) throws ParseException
+    {
+        try
+        {
+            return new FileInputStream(str);
+        }
+        catch (FileNotFoundException e)
+        {
+            throw new ParseException("Unable to find file: " + str);
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -163,7 +163,7 @@ public class PatternOptionBuilderTest
     {
         Options options = PatternOptionBuilder.parsePattern("f<g<");
         CommandLineParser parser = new PosixParser();
-        CommandLine line = parser.parse(options, new String[] { "-f", "test.properties", "-g", "build.xml" });
+        CommandLine line = parser.parse(options, new String[] { "-f", "test.properties", "-g", "/dev/null" });
         
         assertNotNull("option g not parsed, or not FileInputStream", (FileInputStream) line.getOptionObject("g"));
         assertNull("option f parsed", (FileInputStream) line.getOptionObject("f"));

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.net.URL;
 import java.util.Calendar;
 import java.util.Date;
@@ -159,13 +160,20 @@ public class PatternOptionBuilderTest
     @Test
     public void testExistingFilePattern() throws Exception
     {
-        Options options = PatternOptionBuilder.parsePattern("f<");
+        Options options = PatternOptionBuilder.parsePattern("f<g<");
         CommandLineParser parser = new PosixParser();
-        CommandLine line = parser.parse(options, new String[] { "-f", "test.properties" });
-
-        assertEquals("f value", new File("test.properties"), line.getOptionObject("f"));
-
-        // todo test if an error is returned if the file doesn't exists (when it's implemented)
+        CommandLine line = parser.parse(options, new String[] { "-f", "test.properties", "-g", "build.xml" });
+        
+        assertNotNull((FileInputStream) line.getOptionObject("g"));
+        
+        try
+        {
+            line.getOptionObject("f");
+            fail("ParseException wasn't thrown");
+        }
+        catch (ParseException e)
+        {
+        }
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.cli;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -164,7 +165,7 @@ public class PatternOptionBuilderTest
         CommandLineParser parser = new PosixParser();
         CommandLine line = parser.parse(options, new String[] { "-f", "test.properties", "-g", "build.xml" });
         
-        assertNotNull((FileInputStream) line.getOptionObject("g"));
+        assertNotNull("option g not parsed, or not FileInputStream", (FileInputStream) line.getOptionObject("g"));
         
         try
         {

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -166,15 +166,7 @@ public class PatternOptionBuilderTest
         CommandLine line = parser.parse(options, new String[] { "-f", "test.properties", "-g", "build.xml" });
         
         assertNotNull("option g not parsed, or not FileInputStream", (FileInputStream) line.getOptionObject("g"));
-        
-        try
-        {
-            line.getOptionObject("f");
-            fail("ParseException wasn't thrown");
-        }
-        catch (ParseException e)
-        {
-        }
+        assertNull("option f parsed", (FileInputStream) line.getOptionObject("f"));
     }
 
     @Test


### PR DESCRIPTION
when the user pass option type FileInputStream.class, I think the expected behavior for the return value is the same type, which the user passed.
Before this there was no check whether the file exist.