### PR TITLE
TRIVIAL: Adjust access-modifier of checkRequiredOptions() to protected

### DIFF
--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -191,7 +191,7 @@ public class DefaultParser implements CommandLineParser
      * @throws MissingOptionException if any of the required Options
      * are not present.
      */
-    private void checkRequiredOptions() throws MissingOptionException
+    protected void checkRequiredOptions() throws MissingOptionException
     {
         // if there are required options that have not been processed
         if (!expectedOpts.isEmpty())


### PR DESCRIPTION
... for parity with GnuParser, PosixParser and Parser impls to allow sub-class a bit more control.

I have a use-case in gshell cli2 which needs to defer the required-options check, which is doable with GnuParser and PosixParser, but the new DefaultParser doesn't allow this due to a private access-modifier on checkRequiredOptions().

https://issues.apache.org/jira/browse/CLI-276