### PR TITLE
CLI-217: Optional partial matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ buildNumber.properties
 .mvn/timing.properties
 !/.mvn/wrapper/maven-wrapper.jar
 
-# vscode/eclipse
+# vscode/eclipse/idea
+*.iml
+.idea/
 .classpath
 .project
 .settings/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-### https://raw.github.com/github/gitignore/f2ce448f2ba7a092da05482ceca99209127c0884/maven.gitignore
-
+# maven
 target/
 pom.xml.tag
 pom.xml.releaseBackup
@@ -9,9 +8,12 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-
-# Exclude maven wrapper
 !/.mvn/wrapper/maven-wrapper.jar
 
-site-content
+# vscode/eclipse
+.classpath
+.project
+.settings/
 
+# other
+site-content

--- a/src/test/java/org/apache/commons/cli/DisablePartialMatchingTest.java
+++ b/src/test/java/org/apache/commons/cli/DisablePartialMatchingTest.java
@@ -33,11 +33,13 @@ public class DisablePartialMatchingTest
 
         options.addOption(new Option("d", "debug", false, "Turn on debug."));
         options.addOption(new Option("e", "extract", false, "Turn on extract."));
+        options.addOption(new Option("o", "option", true, "Turn on option with argument."));
 
-        CommandLine line = parser.parse(options, new String[]{"-de"});
+        CommandLine line = parser.parse(options, new String[]{"-de", "--option=foobar"});
 
         assertTrue("There should be an option debug in any case...", line.hasOption("debug"));
         assertTrue("There should be an extract option because partial matching is off", line.hasOption("extract"));
+        assertTrue("There should be an option option with a argument value", line.hasOption("option"));
     }
 
     @Test
@@ -49,10 +51,13 @@ public class DisablePartialMatchingTest
 
         options.addOption(new Option("d", "debug", false, "Turn on debug."));
         options.addOption(new Option("e", "extract", false, "Turn on extract."));
+        options.addOption(new Option("o", "option", true, "Turn on option with argument."));
 
-        CommandLine line = parser.parse(options, new String[]{"-de"});
+
+        CommandLine line = parser.parse(options, new String[]{"-de", "--option=foobar"});
 
         assertTrue("There should be an option debug in any case...", line.hasOption("debug"));
         assertFalse("There should not be an extract option because partial matching only selects debug", line.hasOption("extract"));
+        assertTrue("There should be an option option with a argument value", line.hasOption("option"));
     }
 }

--- a/src/test/java/org/apache/commons/cli/DisablePartialMatchingTest.java
+++ b/src/test/java/org/apache/commons/cli/DisablePartialMatchingTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.cli;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DisablePartialMatchingTest
+{
+    @Test
+    public void testDisablePartialMatching() throws Exception
+    {
+        CommandLineParser parser = new DefaultParser(false);
+
+        final Options options = new Options();
+
+        options.addOption(new Option("d", "debug", false, "Turn on debug."));
+        options.addOption(new Option("e", "extract", false, "Turn on extract."));
+
+        CommandLine line = parser.parse(options, new String[]{"-de"});
+
+        assertTrue("There should be an option debug in any case...", line.hasOption("debug"));
+        assertTrue("There should be an extract option because partial matching is off", line.hasOption("extract"));
+    }
+
+    @Test
+    public void testRegularPartialMatching() throws Exception
+    {
+        CommandLineParser parser = new DefaultParser();
+
+        final Options options = new Options();
+
+        options.addOption(new Option("d", "debug", false, "Turn on debug."));
+        options.addOption(new Option("e", "extract", false, "Turn on extract."));
+
+        CommandLine line = parser.parse(options, new String[]{"-de"});
+
+        assertTrue("There should be an option debug in any case...", line.hasOption("debug"));
+        assertFalse("There should not be an extract option because partial matching only selects debug", line.hasOption("extract"));
+    }
+}


### PR DESCRIPTION
At request of Gary, I (re)created an old patch against the current code base to enable partial matching to be set as optional. This fixes problems for people that have short options that, concatenated, also partial-match a long option.

For example:
    -d, --debug
    -e, --extract

    foo -de

Is ambiguous in the case that partial matching is enabled. This patch allows a user to turn off partial matching in such a case.