### PR TITLE
.travis.yml: install open-jdk6, as it was removed from the default image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,13 @@ addons:
     packages:
       - openjdk-6-jdk
 
+# use java 6 compatible maven version (installed into target directory so rat check passes)
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip -P ./target
+  - unzip -qq ./target/apache-maven-3.2.5-bin.zip -d ./target
+  - export M2_HOME=$PWD/target/apache-maven-3.2.5
+  - export PATH=$M2_HOME/bin:$PATH
+
 jdk:
   - openjdk6
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@
 language: java
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 jdk:
   - openjdk6
   - openjdk7


### PR DESCRIPTION
(see https://github.com/travis-ci/travis-ci/issues/8199)