### PR TITLE
Add module-info

### DIFF
--- a/src/main/java/org.apache.commons.cli/module-info.java
+++ b/src/main/java/org.apache.commons.cli/module-info.java
@@ -1,0 +1,3 @@
+module org.apache.commons.cli {
+	exports org.apache.commons.cli;
+}


### PR DESCRIPTION
This should modularize commons-cli. We may have to do another commit to get maven to build modularized jars by default, but as of this build javac works perfectly.