### PR TITLE
CLI-216 - Make option-concatenation configurable

### DIFF
--- a/src/test/java/org/apache/commons/cli/DisableOptionConcatenationTest.java
+++ b/src/test/java/org/apache/commons/cli/DisableOptionConcatenationTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DisableOptionConcatenationTest
+{
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testDisableOptionConcatenation() throws Exception
+    {
+        CommandLineParser parser = new DefaultParser.Builder()
+            .withConcatenatedOptions(false)
+            .build();
+
+        final Options options = new Options();
+
+        options.addOption(new Option("f", "file", true, "Load the file."));
+
+        thrown.expect(UnrecognizedOptionException.class);
+
+        parser.parse(options, new String[]{"-fabc"});
+    }
+
+    @Test
+    public void testEnabledOptionConcatenation() throws Exception
+    {
+        CommandLineParser parser = new DefaultParser();
+
+        final Options options = new Options();
+
+        options.addOption(new Option("f", "file", true, "Load the file."));
+
+        CommandLine line = parser.parse(options, new String[]{"-fabc"});
+
+        assertTrue("There should be an option 'file'...", line.hasOption("file"));
+        assertEquals("The 'file' option's value...", "abc", line.getOptionValue("file"));
+    }
+}

--- a/src/test/java/org/apache/commons/cli/DisablePartialMatchingTest.java
+++ b/src/test/java/org/apache/commons/cli/DisablePartialMatchingTest.java
@@ -27,7 +27,9 @@ public class DisablePartialMatchingTest
     @Test
     public void testDisablePartialMatching() throws Exception
     {
-        CommandLineParser parser = new DefaultParser(false);
+        CommandLineParser parser = new DefaultParser.Builder()
+            .withPartialMatching(false)
+            .build();
 
         final Options options = new Options();
 


### PR DESCRIPTION
* Add a DefaultParser.Builder class to make it easier to configure a DefaultParser.
* Add a "concatenated-options" setting.
* Make allow* data members final in DefaultParser.