### PR TITLE
CLI-283 Fixes bugs in CommandLine.java which could possible lead to Null pointer

### DIFF
--- a/src/main/java/org/apache/commons/cli/CommandLine.java
+++ b/src/main/java/org/apache/commons/cli/CommandLine.java
@@ -230,7 +230,9 @@ public class CommandLine implements Serializable
         {
             if (processedOption.equals(option))
             {
-                values.addAll(processedOption.getValuesList());
+                List valuesList = processedOption.getValuesList();
+                if (valuesList != null)
+                    values.addAll(valuesList);
             }
         }
 
@@ -258,6 +260,9 @@ public class CommandLine implements Serializable
     private Option resolveOption(String opt)
     {
         opt = Util.stripLeadingHyphens(opt);
+        if (opt == null)
+            return null;
+
         for (final Option option : options)
         {
             if (opt.equals(option.getOpt()))
@@ -469,7 +474,8 @@ public class CommandLine implements Serializable
      */
     protected void addOption(final Option opt)
     {
-        options.add(opt);
+        if (opt != null)
+            options.add(opt);
     }
 
     /**


### PR DESCRIPTION
Explanation to code changes is given below

- [CommandLine.java #L233](https://github.com/apache/commons-cli/blob/b0024d482050a08efc36c3cabee37c0af0e57a10/src/main/java/org/apache/commons/cli/CommandLine.java#L233)<https://github.com/apache/commons-cli/blob/b0024d482050a08efc36c3cabee37c0af0e57a10/src/main/java/org/apache/commons/cli/CommandLine.java#L233>  Method call to `getValuesList()` returns the possible values of `Option` for which it is called as List or returns `null`. In case it returns `null`, `addAll()` method call on type `List` with `null` as an argument will lead to a NullPointerException. This can be prevented by explicitly checking and handling the cases when it might return null. I have made changes for the same

- [CommandLine.java #L260 ](https://github.com/apache/commons-cli/blob/b0024d482050a08efc36c3cabee37c0af0e57a10/src/main/java/org/apache/commons/cli/CommandLine.java#L260)<https://github.com/apache/commons-cli/blob/b0024d482050a08efc36c3cabee37c0af0e57a10/src/main/java/org/apache/commons/cli/CommandLine.java#L260>As per the implementation of `stripLeadingHyphens(String)`, there exists cases when it might return `null`. And calling `equals` method on a null return value ([#L263](https://github.com/apache/commons-cli/blob/b0024d482050a08efc36c3cabee37c0af0e57a10/src/main/java/org/apache/commons/cli/CommandLine.java#L263)) will lead to null pointer exception. So as to prevent this I have made changes to explicitly return null in case `stripLeadingHyphens` returns null

- [CommandLine.java #L472](https://github.com/apache/commons-cli/blob/b0024d482050a08efc36c3cabee37c0af0e57a10/src/main/java/org/apache/commons/cli/CommandLine.java#L472) <https://github.com/apache/commons-cli/blob/b0024d482050a08efc36c3cabee37c0af0e57a10/src/main/java/org/apache/commons/cli/CommandLine.java#L472> There is a possibility that `addOption` method is called with null as an argument. In that case we will be adding null values to our list of processed options (as `List` does not thrown any null pointer exception even if `add` method is called with null values). So as to prevent this we need to make sure that value that we are adding to list of processed option is not null.