### PR TITLE
CLI-284: Fix inconsistent behaviour for short and long name == null

### DIFF
--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -143,6 +143,13 @@ public class Option implements Cloneable, Serializable
         // ensure that the option is valid
         OptionValidator.validateOption(opt);
 
+        // contract says: "An Option is required to have
+        // at least a short or a long-name."
+        if (opt == null && longOpt == null)
+        {
+            throw new IllegalArgumentException("Either short or long representation is required.");
+        }
+
         this.opt = opt;
         this.longOpt = longOpt;
 

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI284Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI284Test.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.cli.bug;
+
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.ParseException;
+import org.junit.Test;
+
+/*
+   https://issues.apache.org/jira/browse/CLI-284
+*/
+public class BugCLI284Test
+{
+    @Test(expected = IllegalArgumentException.class)
+    public void testShortAndLongNull() throws ParseException {
+        new Option(null, null);
+    }
+}


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CLI-284
