### PR TITLE
CLI-289 - Adding a complementary arg feature

### DIFF
--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -159,6 +159,8 @@ public class DefaultParser implements CommandLineParser
 
         cmd = new CommandLine();
 
+        checkRequiredComplementaryArgs();
+
         if (arguments != null)
         {
             for (final String argument : arguments)
@@ -672,6 +674,24 @@ public class DefaultParser implements CommandLineParser
         else
         {
             currentOption = null;
+        }
+    }
+
+    /**
+     * Throw a {@link MissingComplementaryArgument} if the current option
+     * didn't receive all the complementary args it expects
+     */
+    private void checkRequiredComplementaryArgs() throws MissingComplementaryArgument
+    {
+        for (Option currentOption : options.getOptions()) {
+            List<String> complementaryArgsShortOrLong = currentOption.getComplementaryArgs();
+            for (String complementaryArg : complementaryArgsShortOrLong) {
+                if (options.getOption(complementaryArg) == null) {
+                    String errorMsg = String.format("Missing complementary arg %s for option %s",
+                            complementaryArg, currentOption.getKey());
+                    throw new MissingComplementaryArgument(errorMsg);
+                }
+            }
         }
     }
 

--- a/src/main/java/org/apache/commons/cli/MissingComplementaryArgument.java
+++ b/src/main/java/org/apache/commons/cli/MissingComplementaryArgument.java
@@ -1,0 +1,23 @@
+package org.apache.commons.cli;
+
+/**
+ * Thrown when during the parsing we identify that there are missing complementary arguments
+ * for an option that we have used
+ */
+public class MissingComplementaryArgument extends ParseException {
+
+    /**
+     * This exception {@code serialVersionUID}.
+     */
+    private static final long serialVersionUID = -7098538588704965232L;
+
+    /**
+     * Construct a new <code>ParseException</code>
+     * with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public MissingComplementaryArgument(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -19,6 +19,7 @@ package org.apache.commons.cli;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -79,6 +80,11 @@ public class Option implements Cloneable, Serializable
     private char valuesep;
 
     /**
+     * the list of complementary arguments to be used in conjunction with this option
+     */
+    private List<String> complementaryArgs = Collections.emptyList();
+
+    /**
      * Private constructor used by the nested Builder class.
      * 
      * @param builder builder used to create this option
@@ -94,6 +100,7 @@ public class Option implements Cloneable, Serializable
         this.required = builder.required;
         this.type = builder.type;
         this.valuesep = builder.valuesep;
+        this.complementaryArgs = builder.complementaryArgs;
     }
     
     /**
@@ -717,6 +724,16 @@ public class Option implements Cloneable, Serializable
     }
 
     /**
+     * The list of complementary args that must be supplied as a part of using this option
+     *
+     * @return
+     */
+    public List<String> getComplementaryArgs()
+    {
+        return complementaryArgs;
+    }
+
+    /**
      * Tells if the option can accept more arguments.
      * 
      * @return false if the maximum number of arguments is reached
@@ -771,7 +788,7 @@ public class Option implements Cloneable, Serializable
     {
         return new Builder(opt);
     }
-    
+
     /**
      * A nested builder class to create <code>Option</code> instances
      * using descriptive methods.
@@ -814,6 +831,9 @@ public class Option implements Cloneable, Serializable
 
         /** the character that is the value separator */
         private char valuesep;
+
+        /** list of complementary args that must be supplied as a part of using this option */
+        private List<String> complementaryArgs = Collections.emptyList();
 
         /**
          * Constructs a new <code>Builder</code> with the minimum
@@ -991,6 +1011,19 @@ public class Option implements Cloneable, Serializable
         public Builder hasArgs()
         {
             numberOfArgs = Option.UNLIMITED_VALUES;
+            return this;
+        }
+
+        /**
+         * Adds a list of required options that must also be supplied whenever
+         * this option is used
+         *
+         * @param requiredOptions
+         * @return
+         */
+        public Builder requiresOptions(final List<String> requiredOptions)
+        {
+            this.complementaryArgs = requiredOptions;
             return this;
         }
 

--- a/src/test/java/org/apache/commons/cli/OptionTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionTest.java
@@ -25,6 +25,9 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.List;
+
 public class OptionTest
 {
     private static class TestOption extends Option
@@ -164,36 +167,37 @@ public class OptionTest
     public void testBuilderMethods()
     {
         final char defaultSeparator = (char) 0;
+        final List<String> defaultComplementaryArgs = Collections.emptyList();
 
         checkOption(Option.builder("a").desc("desc").build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultSeparator, String.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultSeparator, String.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").longOpt("aaa").build(),
-            "a", "desc", "aaa", Option.UNINITIALIZED, null, false, false, defaultSeparator, String.class);
+            "a", "desc", "aaa", Option.UNINITIALIZED, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").hasArg(true).build(),
-            "a", "desc", null, 1, null, false, false, defaultSeparator, String.class);
+            "a", "desc", null, 1, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").hasArg(false).build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultSeparator, String.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").hasArg(true).build(),
-            "a", "desc", null, 1, null, false, false, defaultSeparator, String.class);
+            "a", "desc", null, 1, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").numberOfArgs(3).build(),
-            "a", "desc", null, 3, null, false, false, defaultSeparator, String.class);
+            "a", "desc", null, 3, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").required(true).build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, true, false, defaultSeparator, String.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, true, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").required(false).build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultSeparator, String.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
 
         checkOption(Option.builder("a").desc("desc").argName("arg1").build(),
-            "a", "desc", null, Option.UNINITIALIZED, "arg1", false, false, defaultSeparator, String.class);
+            "a", "desc", null, Option.UNINITIALIZED, "arg1", false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").optionalArg(false).build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultSeparator, String.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").optionalArg(true).build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, false, true, defaultSeparator, String.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, false, true, defaultComplementaryArgs, defaultSeparator, String.class);
         checkOption(Option.builder("a").desc("desc").valueSeparator(':').build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, false, false, ':', String.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultComplementaryArgs, ':', String.class);
         checkOption(Option.builder("a").desc("desc").type(Integer.class).build(),
-            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultSeparator, Integer.class);
+            "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultComplementaryArgs, defaultSeparator, Integer.class);
     }
     
     @Test(expected=IllegalArgumentException.class)
@@ -209,7 +213,7 @@ public class OptionTest
     }
 
     private static void checkOption(final Option option, final String opt, final String description, final String longOpt, final int numArgs,
-                                    final String argName,  final boolean required, final boolean optionalArg,
+                                    final String argName,  final boolean required, final boolean optionalArg, List<String> complementaryArgs,
                                     final char valueSeparator, final Class<?> cls)
     {
         assertEquals(opt, option.getOpt());
@@ -220,6 +224,7 @@ public class OptionTest
         assertEquals(required, option.isRequired());
 
         assertEquals(optionalArg, option.hasOptionalArg());
+        assertEquals(complementaryArgs, option.getComplementaryArgs());
         assertEquals(valueSeparator, option.getValueSeparator());
         assertEquals(cls,  option.getType());
     }

--- a/src/test/java/org/apache/commons/cli/ParserTestCase.java
+++ b/src/test/java/org/apache/commons/cli/ParserTestCase.java
@@ -879,6 +879,24 @@ public abstract class ParserTestCase
     }
 
     @Test
+    public void testPresentComplementaryOption() throws ParseException
+    {
+        final String[] args = new String[] { "--test" };
+
+        boolean caught = false;
+        options.addOption(Option.builder().longOpt("test").argName("t").hasArg(false).requiresOptions(Arrays.asList("-c")).build());
+
+        try
+        {
+            parser.parse(options, args);
+        } catch (MissingComplementaryArgument ex) {
+            caught = true;
+        }
+
+        assertFalse("MissingComplementaryArgument isn't caught caught", caught);
+    }
+
+    @Test
     public void testStopBursting() throws Exception
     {
         final String[] args = new String[] { "-azc" };


### PR DESCRIPTION
Should we add the same changes to the deprecated parsers? Problem is that, there will be lots of duplicated code unless we refactor to a base class. Any thoughts?