### PR TITLE
add support priority based iteration over options supplied to CommandLine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,13 @@
         <role>supplied patch</role>
       </roles>
     </contributor>
+    <contributor>
+      <name>Triston Chavez</name>
+      <email>tristonchav@gmail.com</email>
+      <roles>
+        <role>supplied patch</role>
+      </roles>
+    </contributor>
     
   </contributors>
 

--- a/src/main/java/org/apache/commons/cli/CommandLine.java
+++ b/src/main/java/org/apache/commons/cli/CommandLine.java
@@ -20,10 +20,13 @@ package org.apache.commons.cli;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Represents list of arguments parsed against a {@link Options} descriptor.
@@ -40,11 +43,33 @@ public class CommandLine implements Serializable
     /** The serial version UID. */
     private static final long serialVersionUID = 1L;
 
+    /** Allows TreeSet to act as an iterable priority queue that degrades to a plain queue
+     *  when no priority is specified. */
+    private static final Comparator<Option> compare = new Comparator<Option>() {
+        public int compare(Option o1, Option o2) {
+            return o1.getPriority() <= o2.getPriority() ? 1 : -1;
+        }
+    };
+
     /** the unrecognized options/arguments */
     private final List<String> args = new LinkedList<String>();
 
-    /** the processed options */
-    private final List<Option> options = new ArrayList<Option>();
+    /** the processed options. Tweak the definition of contains to fit our use case. */
+    private final Set<Option> options = new TreeSet<Option>(compare){
+        private static final long serialVersionUID = 1L;
+        @Override
+        public boolean contains(Object o){
+            for(Option opt : this) {
+
+                if(opt.equals(o)) {
+                    return true;
+                }
+                
+            }
+
+            return false;
+        }
+    }; 
 
     /**
      * Creates a command line.

--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -78,6 +78,9 @@ public class Option implements Cloneable, Serializable
     /** the character that is the value separator */
     private char valuesep;
 
+    /** the prioirty of this Option */
+    private int priority;
+
     /**
      * Private constructor used by the nested Builder class.
      * 
@@ -94,6 +97,7 @@ public class Option implements Cloneable, Serializable
         this.required = builder.required;
         this.type = builder.type;
         this.valuesep = builder.valuesep;
+        this.priority = builder.priority;
     }
     
     /**
@@ -161,6 +165,8 @@ public class Option implements Cloneable, Serializable
      * statements.
      *
      * @return the id of this Option
+     * @deprecated from Java 7 onwards switch statements support String objects making getKey() a more
+     *             versatile solution.
      */
     public int getId()
     {
@@ -168,14 +174,14 @@ public class Option implements Cloneable, Serializable
     }
 
     /**
-     * Returns the 'unique' Option identifier.
+     * Returns the 'unique' Option identifier. Defaults to shortOpt if present.
      * 
      * @return the 'unique' Option identifier
      */
-    String getKey()
+    public String getKey()
     {
         // if 'opt' is null, then it is a 'long' option
-        return (opt == null) ? longOpt : opt;
+        return (opt == null) ? longOpt : opt; 
     }
 
     /** 
@@ -201,6 +207,16 @@ public class Option implements Cloneable, Serializable
     public Object getType()
     {
         return type;
+    }
+    
+    /**
+     * Retreive the priority of this Option.
+     * 
+     * @return The priority of this option
+     */    
+    public int getPriority()
+    {
+        return priority;
     }
 
     /**
@@ -815,6 +831,9 @@ public class Option implements Cloneable, Serializable
         /** the character that is the value separator */
         private char valuesep;
 
+        /** the prioirty of this Option */
+        private int priority;
+
         /**
          * Constructs a new <code>Builder</code> with the minimum
          * required parameters for an <code>Option</code> instance.
@@ -991,6 +1010,17 @@ public class Option implements Cloneable, Serializable
         public Builder hasArgs()
         {
             numberOfArgs = Option.UNLIMITED_VALUES;
+            return this;
+        }
+
+        /**
+         * Indicates the priority of this Option with higher corresponding to a higher priority.
+         * 
+         * @return this builder, to allow method chaining
+         */
+        public Builder priority(int priority)
+        {
+            this.priority = priority;
             return this;
         }
 

--- a/src/test/java/org/apache/commons/cli/ParserTestCase.java
+++ b/src/test/java/org/apache/commons/cli/ParserTestCase.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
@@ -483,6 +484,36 @@ public abstract class ParserTestCase
         
         final List<?> argsleft = cl.getArgList();
         assertEquals("Should be no arg left", 0, argsleft.size());
+    }
+
+    @Test
+    public void testPrioritizedProperties() throws Exception
+    {
+        final Option op1 = Option.builder("a").priority(90).build();
+        final Option op2 = Option.builder("b").priority(70).build();
+        final Option op3 = Option.builder("c").priority(73).build();
+        final Option op4 = Option.builder("d").priority(90).build();
+        final Option op5 = Option.builder("e").build();
+        final Option op6 = Option.builder("f").build();
+        final Options options = new Options()
+                .addOption(op1)
+                .addOption(op2)
+                .addOption(op3)
+                .addOption(op4)
+                .addOption(op5)
+                .addOption(op6);        
+
+        final String[] args = new String[] {"-c", "-f", "-b", "-a", "-d", "-e"};
+        final CommandLine cl = parser.parse(options, args);
+        
+        final Iterator<Option> itr = cl.iterator();
+        assertTrue(itr.hasNext());
+        assertEquals(op1, itr.next());
+        assertEquals(op4, itr.next());
+        assertEquals(op3, itr.next());
+        assertEquals(op2, itr.next());
+        assertEquals(op6, itr.next());
+        assertEquals(op5, itr.next());
     }
 
     @Test


### PR DESCRIPTION
CommandLine stores the options parsed as ArrayList. I changed this to what is essentially an iterable priority queue. I tweaked a TreeSet to act like a priority queue due to iteration order not being guaranteed in a java.util.PriorityQueue instance. The advantage to this is that it reduces complexity on the user end. When order is important currently redundant tracking and management is required to orchestrate the execution order of operations based on provided flags and arguments. With this patch it is possible to easily orchestrate execution order easily eg:

```java
// args = {"a", "b"}
public static void main(String[] args) {
    Option op1 = Option.builder("a").priority(3);
    ...
    Option opN = Option.builder("b").build(99); // Iterator returns in a result of highest to lowest priority, and in a tie it is ordered as queue. 
      
    CommandLine cl = generateCL(ops, args);
    Iterator<Option> itr = generateCL.iterator();
    while(itr.hasNext()) {
      controlSwitch(itr.next());
    }
}

private static void controlSwitch(Option o) {
    String key = o.getKey();
    switch(key) {
      case "op1"
      ... // Do stuff in a knowably ordered fashion.
      case "opN"
    }
}
```