### PR TITLE
Switch from Oracle JDK 8 to Open JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ language: java
 sudo: false
 
 jdk:
+  - openjdk8
   - openjdk11
   - openjdk12
   - openjdk13
   - openjdk-ea
-  - oraclejdk8
 
 script:
   - mvn


### PR DESCRIPTION
Fix broken build [589473088](https://travis-ci.org/apache/commons-cli/builds/589473088) (triggered by https://github.com/apache/commons-cli/commit/684b3c9eb54aa7d5328d1a4e2583c3dbdfe64465) by switching from Oracle JDK 8 to Open JDK 8. Open JDK 8 has already been used by other repositories of Apache Commons, such as [commons-math](https://github.com/apache/commons-math/blob/master/.travis.yml#L20), [commons-io](https://github.com/apache/commons-io/blob/master/.travis.yml#L20), and [commons-lang](https://github.com/apache/commons-lang/blob/master/.travis.yml#L18).