### PR TITLE
New sources for defining CLI options via a configuration file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ site-content
 /.classpath
 /.project
 /.settings/
+/nb-configuration.xml

--- a/src/main/java/org/apache/commons/cli/config/CommandLineConfiguration.java
+++ b/src/main/java/org/apache/commons/cli/config/CommandLineConfiguration.java
@@ -1,0 +1,269 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+/**
+ * Main entry point to the configuration library.
+ *
+ * <p>
+ * Combines processing a command line configuration file and passes the options
+ * to the command line parser. Listeners should register themselves with this
+ * instance in order to be notified of options as they are encountered.
+ *
+ * <p>
+ * Configuration comes in two forms, each in the same file - <i>global</i> or
+ * <i>option</i> configurations. {@link GlobalConfiguration} enables the
+ * definition of command line help properties (command name, header, footer
+ * etc.) as well as what combination of options to use - short, long or both.
+ * {@link OptionConfiguration}s enable users to define options that are
+ * programmatically built into {@link Options} and dealt with under the hood.
+ * All that is required is that an {@link OptionListener} is added as a listener
+ * and contains the code to execute when different options are passed in.
+ *
+ * <p>
+ * By default, no global options are required and only one option configuration
+ * is required minimum to get going. Regardless, all global options must be
+ * defined before any standard options, otherwise an error will be thrown. Each
+ * option configuration takes the form of {@code option.[optionName].[property]}
+ * where each {@code property} is a pre-defined configuration proeprty defined
+ * in {@link OptionConfiguration}.
+ *
+ * <p>
+ * An example of using the command line configuration - see
+ * {@link OptionListener} for how a listener would deal with the updates from
+ * the processing of command line arguments, and {@link OptionConfiguration} for
+ * an example configuration that matches this example:
+ *
+ * <pre>
+ * {@code
+ * MyAppListener listener = new MyAppListener();
+ InputStream is = ConfigParserTest.class.getResourceAsStream("opt.config");
+ CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+ cliConfig.addOptionListener(listener);
+ // args[] from the public static void main(String[] args) call:
+ cliConfig.process(is, args);
+ Application application = new Application();
+ if (listener.file != null && listener.text != null)
+ {
+      application.write(listener.file, listener.text, listener.overwrite);
+ }
+ else
+ {
+      System.err.println("File and text must be supplied.");
+      System.exit(1);
+ }
+ }
+ * </pre>
+ */
+public class CommandLineConfiguration
+{
+
+    /**
+     * Listeners to be notified of updates.
+     */
+    private final List<OptionListener> listeners = new ArrayList<>();
+
+    /**
+     * Global configuration parsed by this CLI configuration.
+     */
+    private GlobalConfiguration globalConfig;
+
+    /**
+     * Options parsed from the command line parser.
+     */
+    private List<Option> parsedOptions;
+
+    /**
+     * Options built up from converting {@link OptionConfiguration}s.
+     */
+    private Options options;
+
+    /**
+     * Take the given input stream and arguments and process them, informing all
+     * registered listeners of any options that are parsed along with their
+     * values. Note that if both short and long options are used, listeners will
+     * be notified twice for each option; it is up to listeners to cater for
+     * this to their needs.
+     *
+     * @param is non-{@code null} readable input stream of a command line
+     * configuration to parse.
+     *
+     * @param args non-{@code null} arguments, typically supplied via a call
+     * from a command line process.
+     *
+     * @throws ConfigurationException if the configuration file contains any invalid
+     * definitions.
+     *
+     * @throws IOException if there is a problem reading the input stream.
+     */
+    public void process(final InputStream is, final String[] args)
+            throws ConfigurationException, IOException
+    {
+        final ConfigurationParser configParser = new ConfigurationParser();
+        globalConfig = configParser.parse(is);
+        final Map<String, OptionConfiguration> optionConfig = globalConfig.getOptionConfigurations();
+        options = buildOptions(optionConfig);
+        final CommandLineParser parser = new DefaultParser();
+        final CommandLine cli;
+        try
+        {
+            cli = parser.parse(options, args);
+        }
+        catch (ParseException ex)
+        {
+            throw new ConfigurationException(ex.getMessage(), ex);
+        }
+
+        // if help has been defined, this is done for the user
+        if (globalConfig.getHelpOptionName() != null)
+        {
+            OptionConfiguration optionHelp = optionConfig.get(
+                    globalConfig.getHelpOptionName());
+            if (optionHelp.hasArg())
+            {
+                throw new ConfigurationException("Error: Option "
+                        + optionHelp.getName() + " cannot have an argument"
+                        + " associated with it.");
+            }
+            // see if the caller has asked for help
+            String optionHelpValue = optionHelp.getShortOption();
+            if (optionHelpValue == null)
+            {
+                // they specified long options only so short option will be null
+                optionHelpValue = optionHelp.getLongOption();
+            }
+            if (cli.hasOption(optionHelpValue))
+            {
+                printHelp();
+                System.exit(0);
+            }
+        }
+
+        final Option[] cliOptions = cli.getOptions();
+        parsedOptions = Arrays.asList(cliOptions);
+        for (final Option option : cliOptions)
+        {
+            for (int i = 0; i < listeners.size(); i++)
+            {
+                if (option.getOpt() != null)
+                {
+                    listeners.get(i).option(option.getOpt(), option.getValue());
+                }
+                if (option.getLongOpt() != null)
+                {
+                    listeners.get(i).option(option.getLongOpt(),
+                            option.getValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * Used if the caller wants to define their own help configuration or have
+     * access to the underlying options.
+     *
+     * @return the non-{@code null} options.
+     */
+    public List<Option> getOptions()
+    {
+        return parsedOptions;
+    }
+
+    /**
+     * Use the {@link HelpFormatter} to print help - for the help to contain
+     * informative information, see {@link GlobalConfiguration} on how global
+     * options can be set to inform the user of values to define in order to
+     * create a valid help listing.
+     */
+    public void printHelp()
+    {
+        // print help, then quit
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp(globalConfig.getHelpCommandName(),
+                globalConfig.getHelpCommandHeader(), options,
+                globalConfig.getHelpCommandFooter());
+    }
+
+    /**
+     * Add the specified listener.
+     *
+     * @param listener non-{@code null} listener to add.
+     *
+     * @return {@code true} if the listener was added, {@code false} otherwise.
+     */
+    public boolean addOptionListener(final OptionListener listener)
+    {
+        return listeners.add(listener);
+    }
+
+    /**
+     * Remove the specified listener.
+     *
+     * @param listener non-{@code null} listener to remove.
+     *
+     * @return {@code true} if the listener was removed, {@code false}
+     * otherwise.
+     */
+    public boolean removeOptionListener(final OptionListener listener)
+    {
+        return listeners.remove(listener);
+    }
+
+    /**
+     * Convert the specified map of configurations to valid command line
+     * options.
+     *
+     * @param map non-{@code null} map of configuration options.
+     *
+     * @return Options based on the converted map.
+     */
+    private Options buildOptions(final Map<String, OptionConfiguration> map)
+    {
+        final Options options = new Options();
+        for (OptionConfiguration optConfig : map.values())
+        {
+            final String shortOption = optConfig.getShortOption();
+            final String longOption = optConfig.getLongOption();
+            final String description = optConfig.getDescription();
+            final String argName = optConfig.getArgName();
+            final boolean hasArg = optConfig.hasArg();
+            final Option option = new Option(shortOption, longOption, hasArg,
+                    description);
+            if (argName != null)
+            {
+                option.setArgName(argName);
+            }
+            options.addOption(option);
+        }
+        return options;
+    }
+
+}

--- a/src/main/java/org/apache/commons/cli/config/ConfigurationException.java
+++ b/src/main/java/org/apache/commons/cli/config/ConfigurationException.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+/**
+ * Represents an exception for incorrect definition and usage of a configuration
+ * file.
+ */
+public class ConfigurationException extends Exception
+{
+
+    /**
+     * Constructs an instance of <code>ConfigException</code> with the specified
+     * detail message.
+     *
+     * @param message the detail message.
+     */
+    public ConfigurationException(final String message)
+    {
+        super(message);
+    }
+
+    /**
+     * Constructs an instance of <code>ConfigException</code> with the specified
+     * detail message.
+     *
+     * @param lineNo line number
+     *
+     * @param message the detail message.
+     */
+    public ConfigurationException(final Integer lineNo, final String message)
+    {
+        super("Line no. " + lineNo + ": " + message);
+    }
+
+    /**
+     * Creates a new instance of <code>ConfigException</code> with the specified
+     * detail message and cause.
+     *
+     * @param message the message detail.
+     *
+     * @param cause the cause of the exception.
+     */
+    public ConfigurationException(final String message, final Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/apache/commons/cli/config/ConfigurationParser.java
+++ b/src/main/java/org/apache/commons/cli/config/ConfigurationParser.java
@@ -1,0 +1,411 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The configuration parser takes an input stream and generates the
+ * {@link GlobalConfiguration} and {@link OptionConfiguration} objects obtained
+ * from the stream.
+ *
+ */
+public class ConfigurationParser
+{
+
+    /**
+     * All alphabetic characters regular expression.
+     */
+    static final String A_Z = "a-zA-Z";
+
+    /**
+     * Numbers regular expression.
+     */
+    static final String ALPHA_NUM = A_Z + "0-9";
+
+    /**
+     * Regular expression to match short options.
+     */
+    static final String SHORT_OPTION_FORMAT = "([" + ALPHA_NUM + "])";
+
+    /**
+     * Regular expression to match long options.
+     */
+    static final String LONG_OPTION_FORMAT = "([" + ALPHA_NUM + "\\-]+)";
+
+    /**
+     * Regular expression for lines matching the start of a
+     * {@link OptionConfiguration} declaration (before the '=').
+     */
+    static final String OPTION_REGEX_PREFIX = "\\s*option\\.([" + ALPHA_NUM
+            + "\\-_]*)\\.([" + A_Z + "\\-_]*)";
+
+    /**
+     * Regular expression for an entire line of an {@link OptionConfiguration}.
+     */
+    static final String OPTION_REGEX_BASIC_LINE = OPTION_REGEX_PREFIX
+            + "=(.*)\\s*\\\\{0,1}";
+
+    /**
+     * Regular expression for an escaped line.
+     */
+    static final String OPTION_REGEX_ESCAPED_LINE = "\\s+(.*)\\s*\\\\{0,1}";
+
+    /**
+     * Defines the option value(s) for a given configuration - these will be the
+     * long and/or short option for the configuration.
+     */
+    static final String OPTS = "opts";
+
+    /**
+     * Defines the constant string used to define a description for a
+     * configuration.
+     */
+    static final String DESCRIPTION = "description";
+
+    /**
+     * Defines the constant string to define if a given configuration uses an
+     * argument.
+     */
+    static final String HAS_ARG = "hasArg";
+
+    /**
+     * Defines the constant for the configuration argument name, if the
+     * configuration has an argument; this is the name that will be suffixed
+     * (for example) when a user invokes help in order to print out the
+     * different options.
+     */
+    static final String ARG_NAME = "argName";
+
+    /**
+     * Defines the constant for providing a default value for a configuration.
+     */
+    static final String DEFAULT = "default";
+
+    /**
+     * Parse the input stream and create the option configuration.
+     *
+     * @param is non-{@code null} input stream to read.
+     *
+     * @return the option configuration read from the input stream.
+     *
+     * @throws ConfigurationException if any of the configuration options are not
+     * defined correctly, or there are no options defined.
+     *
+     * @throws IOException if the input stream could not be read.
+     */
+    public GlobalConfiguration parse(final InputStream is)
+            throws ConfigurationException, IOException
+    {
+        final InputStreamReader isr = new InputStreamReader(is);
+        final BufferedReader buf = new BufferedReader(isr);
+        String line = "";
+        String builtLine = null;
+        int currentLineNo = 0;
+        boolean globalConfigParsed = false;
+        final GlobalConfiguration globalConfig = new GlobalConfiguration();
+        while ((line = buf.readLine()) != null)
+        {
+            currentLineNo++;
+            if (line.trim().startsWith("#") || line.isEmpty())
+            {
+                continue;
+            }
+            boolean lineEscaped = false;
+            if (builtLine != null && line.matches(OPTION_REGEX_ESCAPED_LINE))
+            {
+                // it's not null so we must be building up the data; the
+                // previous line must have been an escaped line (as could this one)
+                // first, remove leading spaces/tabs:
+                final String stripLeading = line.replaceAll("^\\s+", "");
+                int lastIndex = stripLeading.length();
+                if (stripLeading.trim().endsWith("\\"))
+                {
+                    // it's another escaped line - keep building it up:
+                    lineEscaped = true;
+                    lastIndex = stripLeading.lastIndexOf('\\');
+                }
+                else
+                {
+                    // the line is complete based on previous escaped lines
+                }
+                builtLine += stripLeading.substring(0, lastIndex);
+                if (lineEscaped)
+                {
+                    continue;
+                }
+            }
+            else if (builtLine != null)
+            {
+                // doesn't match our regular expression
+                throw new ConfigurationException(currentLineNo,
+                        "Invalid escaped line: " + line);
+            }
+            if (builtLine == null)
+            {
+                // new line data to read
+                if (line.endsWith("\\"))
+                {
+                    // start of an escaped line, build it up from here:
+                    builtLine = line.substring(0, line.lastIndexOf("\\"));
+                    continue;
+                }
+                else
+                {
+                    // new line and it's complete and ready to go
+                    builtLine = line;
+                }
+            }
+            if (builtLine.trim().matches(GlobalConfiguration.OPTION_REGEX))
+            {
+                // if this is /after/ any standard options, throw an exception
+                // since all global options must come /before/ standard options
+                if (globalConfigParsed)
+                {
+                    throw new ConfigurationException(currentLineNo, "Invalid global"
+                            + " configuration definition; global configurations"
+                            + " must come BEFORE standard \"option...\" definitions");
+                }
+                // it's a pattern of the form ABC_XYZ=[text], let the global
+                // configuration deal with it:
+                try
+                {
+                    globalConfig.updateGlobalConfiguration(builtLine);
+                    // global configuration updated, carry on
+                    builtLine = null;
+                }
+                catch (ConfigurationException ex)
+                {
+                    throw new ConfigurationException(currentLineNo, ex.getMessage());
+                }
+            }
+            else if (builtLine.matches(OPTION_REGEX_BASIC_LINE))
+            {
+                // there shall be no more global definitions after this:
+                globalConfigParsed = true;
+                final Pattern p = Pattern.compile(ConfigurationParser.OPTION_REGEX_BASIC_LINE);
+                final Matcher m = p.matcher(builtLine);
+                boolean boo = m.matches();
+                // reset the line for next time, we're done
+                final String name = m.group(1);
+                final String subOption = m.group(2);
+                final String value = m.group(3);
+                updateCurrentOption(globalConfig, name, subOption,
+                        value, currentLineNo);
+                builtLine = null;
+            }
+            else
+            {
+                // doesn't match our regular expression
+                throw new ConfigurationException(currentLineNo, "Invalid option"
+                        + " definition: " + line);
+            }
+        }
+        if (globalConfig.getOptionConfigurations().isEmpty())
+        {
+            // there were no options in the file
+            throw new ConfigurationException("The configuration file contained no"
+                    + " options to parse");
+        }
+        buf.close();
+        isr.close();
+        return globalConfig;
+    }
+
+    /**
+     * Given the specified name, update the current option detected in the
+     * configuration file and determine if this option is a new configuration,
+     * an existing configuration that is still being built, or the next
+     * configuration.
+     *
+     * @param globalConfig non-{@code null} global configuration data.
+     *
+     * @param name non-{@code null} name of the option currently being examined.
+     *
+     * @param subOption non-{@code null} the sub-option being parsed, for
+     * example 'description', 'hasArg'.
+     *
+     * @param value non-{@code null} the value of the option being examined.
+     *
+     * @param currentLineNo current line number of the input stream being
+     * parsed.
+     *
+     * @throws ConfigurationException if there are any problems extracting the data.
+     */
+    private void updateCurrentOption(
+            final GlobalConfiguration globalConfig, final String name,
+            final String subOption, final String value, final int currentLineNo)
+            throws ConfigurationException
+    {
+        OptionConfiguration currentOption = globalConfig.getOptionConfigurations().get(name);
+        if (currentOption == null)
+        {
+            // it's a new option configuration:
+            currentOption = new OptionConfiguration();
+            currentOption.setName(name);
+            globalConfig.addOptionConfiguration(currentOption);
+        }
+        if (OPTS.equals(subOption))
+        {
+            OptionsTypeEnum optionsType = null;
+            final String opt = value.trim();
+            if (opt.contains("/"))
+            {
+                optionsType = OptionsTypeEnum.BOTH;
+            }
+            else if (opt.length() == 1)
+            {
+                optionsType = OptionsTypeEnum.SHORT;
+            }
+            else if (opt.length() > 1)
+            {
+                optionsType = OptionsTypeEnum.LONG;
+            }
+            else
+            {
+                String message = "Empty option value; must be a non-zero length"
+                        + " string";
+                // zero characters or null
+                if (globalConfig.getOptionsType() != null)
+                {
+                    // already set, inform them of their decision
+                    message += "; global configuration is defined as "
+                            + globalConfig.getOptionsType().getType();
+                }
+                throw new ConfigurationException(currentLineNo, message);
+
+            }
+            checkCurrentOption(globalConfig, optionsType, currentOption, opt,
+                    currentLineNo);
+        }
+        else if (DESCRIPTION.equals(subOption))
+        {
+            currentOption.setDescription(value);
+        }
+        else if (HAS_ARG.equals(subOption))
+        {
+            currentOption.setHasArg(Boolean.parseBoolean(value));
+        }
+        else if (ARG_NAME.equals(subOption))
+        {
+            currentOption.setArgName(value);
+        }
+        else if (DEFAULT.equals(subOption))
+        {
+            // TODO
+        }
+        else
+        {
+            throw new ConfigurationException(currentLineNo,
+                    "Unknown configuration option: " + subOption);
+        }
+    }
+
+    /**
+     * Check that the option specified is of the correct type - short, long or
+     * both - according to what has been defined in the global configuration (if
+     * it has been defined), setting it if it hasn't and this is the first
+     * option in the configuration and the option conforms to the expected type.
+     *
+     * @param globalConfig non-{@code null} global configuration.
+     *
+     * @param expectedType non-{@code null} expected type.
+     *
+     * @param currentOption non-{@code null} current option being parsed that
+     * does not yet have the specified option set on it yet.
+     *
+     * @param option non-{@code null} option.
+     *
+     * @param currentLineNo current line number of where the data is encountered
+     * in the input stream.
+     *
+     * @throws ConfigurationException if the specified option does not match the global
+     * configuration's option type or the option formatting is incorrect (such
+     * as specifying a short option when the option type is long option).
+     */
+    private void checkCurrentOption(final GlobalConfiguration globalConfig,
+            final OptionsTypeEnum expectedType,
+            final OptionConfiguration currentOption, final String option,
+            final int currentLineNo)
+            throws ConfigurationException
+    {
+        final OptionsTypeEnum globalOptType = globalConfig.getOptionsType();
+        if (globalOptType != null && !(globalOptType.equals(expectedType)))
+        {
+            throw new ConfigurationException(currentLineNo,
+                    "Configuration type specifies "
+                    + GlobalConfiguration.OPTION_TYPE + " as "
+                    + globalOptType.getType() + " but found "
+                    + expectedType);
+        }
+        if (globalOptType == null)
+        {
+            globalConfig.setOptionsType(expectedType);
+        }
+        if (globalConfig.getOptionsType() == OptionsTypeEnum.BOTH)
+        {
+            final String forwardSlash = "/";
+            final Pattern p = Pattern.compile(SHORT_OPTION_FORMAT
+                    + forwardSlash + LONG_OPTION_FORMAT);
+            final Matcher m = p.matcher(option);
+            if (m.matches())
+            {
+                currentOption.setShortOption(m.group(1));
+                currentOption.setLongOption(m.group(2));
+            }
+            else
+            {
+                throw new ConfigurationException(currentLineNo, "Invalid short and"
+                        + " long option format; must be [character]/"
+                        + " [text] but found " + option);
+            }
+        }
+        else if (globalConfig.getOptionsType() == OptionsTypeEnum.SHORT)
+        {
+            final Pattern p = Pattern.compile(SHORT_OPTION_FORMAT);
+            final Matcher m = p.matcher(option);
+            if (m.matches())
+            {
+                currentOption.setShortOption(m.group(1));
+            }
+            else
+            {
+                throw new ConfigurationException(currentLineNo, "Expected single"
+                        + " character for short option but found " + option);
+            }
+        }
+        else
+        {
+            final Pattern p = Pattern.compile(LONG_OPTION_FORMAT);
+            final Matcher m = p.matcher(option);
+            if (m.matches())
+            {
+                currentOption.setLongOption(m.group(1));
+            }
+            else
+            {
+                throw new ConfigurationException(currentLineNo, "Expected text"
+                        + " for long option but found " + option);
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/commons/cli/config/GlobalConfiguration.java
+++ b/src/main/java/org/apache/commons/cli/config/GlobalConfiguration.java
@@ -1,0 +1,388 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.cli.HelpFormatter;
+
+/**
+ * The global configuration is the configuration for an entire file with at
+ * least one {@link OptionConfiguration}.
+ *
+ * <p>
+ * Lines beginning with &#35; are ignored.
+ *
+ * <p>
+ * Global configuration items are as follows - the global options beginning with
+ * {@code HELP_} enable callers to print help linked to an option without any
+ * code whatsoever (more on this below):
+ *
+ * <ul>
+ *
+ * <li>{@code OPTION_TYPE=[OPTION_TYPE]}: where {@code [OPTION_TYPE]} is one of
+ * {@code BOTH} where both short and long options are used, specified as
+ * {@code [char]/[text]}, {@code SHORT} where only short options are specified
+ * as a single character, and {@code LONG} where only long options are
+ * specified. However, {@code OPTION_TYPE} is not strictly required so long as
+ * the options specified are all consistent (although it aids readability for
+ * others maintaining the file to implicitly define {@code OPTION_TYPE});</li>
+ *
+ * <li>{@code HELP_OPTION_NAME=[optionName]}: where {@code [optionName]} is the
+ * name of an option defined in the options configuration further down in the
+ * options configuration (see {@link OptionConfiguration});</li>
+ *
+ * <li>{@code HELP_COMMAND_NAME=[commandName]}: The command name is the name of
+ * the command that will be printed when the "Usage: commandName..." is printed
+ * from a call to invoking the help option;</li>
+ *
+ * <li>{@code HELP_COMMAND_HEADER=[headerText]}: where {@code [headerText]} is
+ * the text that will be displayed as the header text from an invocation to call
+ * for help to be printed. The command header is optional; and</li>
+ *
+ * <li>{@code HELP_COMMAND_FOOTER=[footerText]}: where {@code [footerText]} is
+ * the text that will be displayed as the footer text from an invocation to call
+ * for help to be printed. Like the header, the command footer is optional.
+ * </li>
+ * </ul>
+ *
+ * In all cases, lines may be escaped; escaped lines must end in a trailing
+ * backslash character; lines to be appended must be indented using white space
+ * (space character and/or tab characters). For example:
+ *
+ * <pre>
+ * HELP_COMMAND_HEADER=Show some useful information, \
+ *     with some extra escaped lines. \
+ *     Also, there's some extra information here about the command.
+ * </pre>
+ *
+ * Note in the above example the spaces before the backslashes - this is so
+ * sentences are not 'glued' together and provide spacing that is easy on the
+ * eye to readers of the output.
+ *
+ * <p>
+ * Regardless of how the lines are escaped with regard to the number of
+ * characters per line, this will not affect the CLI help output since the CLI
+ * {@link HelpFormatter} will format this according to the API rules for line
+ * sizes.
+ *
+ * <p>
+ * For example, by adding the following global options to the start of the 
+ * example file defined in {@link OptionConfiguration}:
+ *
+ * <pre>
+ * # The following definition implies there must be an option.showHelp option
+ * # defined in the options following these global definitions:
+ * HELP_OPTION_NAME=showHelp
+ * HELP_COMMAND_NAME=writeData
+ * HELP_COMMAND_HEADER=Write the specified text to the specified file. If the \
+ *      options contain spaces or special characters, supply the arguments in \
+ *      double quotes.
+ * HELP_COMMAND_FOOTER=Copyleft Foo, Bar &amp; Baz International.
+ * </pre>
+ *
+ * <p>
+ * ... When invoking {@code --help} or {@code -h} via the
+ * {@link CommandLineConfiguration}:
+ *
+ * <pre>
+ * InputStream is = ConfigurationParserTest.class.getResourceAsStream("opt.config");
+ * CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+ * cliConfig.addOptionListener(listener);
+ * // args[] from the public static void main(String[] args) call:
+ * cliConfig.process(is, args);
+ * </pre>
+ *
+ * <p>
+ * ... Would produce the following output and then quit with exit status 0:
+ *
+ * <pre>
+ * usage: writeData
+ * Write the specified text to the specified file. If the options contain
+ * spaces or special characters, supply the arguments in double quotes.
+ *  -f,--file &lt;file&gt;   File to write to.
+ *  -h,--help          Print this help then quit.
+ *  -o,--overwrite     If set, write over the existing file; otherwise,
+ *                     append to the file.
+ *  -t,--text &lt;text&gt;   Text to write to the file.
+ * Copyleft Foo, Bar &amp; Baz International.
+ * </pre>
+ *
+ * <p>
+ * The {@code HELP_} global configuration options are not mandatory and are
+ * there for convenience; however, configuration creators can omit these if they
+ * wish to define their own help (in which case, the {@link OptionListener} must
+ * cater for the call to help).
+ *
+ */
+public class GlobalConfiguration
+{
+
+    /**
+     * Regular expression to match global option configurations. The general
+     * form of a global configuration is upper case characters using underscores
+     * (if necessary) with the value separated by an equals symbol, with the
+     * value being any number of characters (with a minimum of one).
+     */
+    public static final String OPTION_REGEX = "([A-Z_]+)=(.+)";
+
+    /**
+     * Declaration for global option type (short, long, both).
+     */
+    public static final String OPTION_TYPE = "OPTION_TYPE";
+
+    /**
+     * Declaration for the name of the command that will be invoked to show help
+     * options.
+     */
+    public static final String HELP_COMMAND_NAME = "HELP_COMMAND_NAME";
+
+    /**
+     * Declaration for the header of the command that will be shown when
+     * invoking help.
+     */
+    public static final String HELP_COMMAND_HEADER = "HELP_COMMAND_HEADER";
+
+    /**
+     * Declaration for the footer of the command that will be shown when
+     * invoking help.
+     */
+    public static final String HELP_COMMAND_FOOTER = "HELP_COMMAND_FOOTER";
+
+    /**
+     * Declaration for the option name of that is defined in the
+     * {@link OptionConfiguration} such that when that CLI option is invoked,
+     * help will be printed.
+     */
+    public static final String HELP_OPTION_NAME = "HELP_OPTION_NAME";
+
+    /**
+     * The key is the actual name part of the {@code option.[name].*}
+     * declaration, in other words the option name.
+     */
+    private final Map<String, OptionConfiguration> optionMap = new HashMap<>();
+
+    /**
+     * The option type of the configuration.
+     */
+    private OptionsTypeEnum optionsType;
+
+    /**
+     * If the global configuration has help defined, this is the name of the
+     * command that will be printed with the help text.
+     */
+    private String helpCommandName;
+
+    /**
+     * If the global configuration has help defined, this is the header text of
+     * the command that will be printed with the help text.
+     */
+    private String helpCommandHeader;
+
+    /**
+     * If the global configuration has help defined, this is the footer text of
+     * the command that will be printed with the help text.
+     */
+    private String helpCommandFooter;
+
+    /**
+     * The option configuration name {@code option.[name]}, for example,
+     * {@code option.help}.
+     */
+    private String helpOptionName;
+
+    /**
+     * Update the given global configuration with the specified line data read.
+     *
+     * @param line non-{@code null} line data to parse that matches
+     * {@link #OPTION_REGEX}.
+     *
+     * @throws ConfigurationException if the configuration is defined incorrectly.
+     */
+    public void updateGlobalConfiguration(String line) throws ConfigurationException
+    {
+        String[] data = line.split("=");
+        if (data[0].trim().matches(GlobalConfiguration.OPTION_TYPE))
+        {
+            parseOptionType(data[1].trim());
+        }
+        else if (data[0].trim().startsWith("HELP"))
+        {
+            parseHelp(line);
+        }
+        else
+        {
+            throw new ConfigurationException(
+                    "Unknown global configuration declaration: " + data[0].trim());
+        }
+    }
+
+    /**
+     * Get the name of the command that will be printed when (if) the user has
+     * defined help.
+     *
+     * @return the name of the command that the help displays information for.
+     */
+    public String getHelpCommandName()
+    {
+        return helpCommandName;
+    }
+
+    /**
+     * Get the help command header.
+     *
+     * @return the command header, if it has been set; {@code null} otherwise.
+     */
+    public String getHelpCommandHeader()
+    {
+        return helpCommandHeader;
+    }
+
+    /**
+     * Get the help command footer.
+     *
+     * @return the command footer, if it has been set; {@code null} otherwise.
+     */
+    public String getHelpCommandFooter()
+    {
+        return helpCommandFooter;
+    }
+
+    /**
+     * Get the option name specified by the global configuration; the name is
+     * the name of the {@link OptionConfiguration} that must exist in the option
+     * configurations.
+     *
+     * @return the help option name if it is set; {@code null} otherwise.
+     */
+    public String getHelpOptionName()
+    {
+        return helpOptionName;
+    }
+
+    /**
+     * Add the specified option configuration.
+     *
+     * @param optionConfig non-{@code null} option configuration to add.
+     */
+    public void addOptionConfiguration(OptionConfiguration optionConfig)
+    {
+        optionMap.put(optionConfig.getName(), optionConfig);
+    }
+
+    /**
+     * Get the option map for this configuration; the key to the map will be the
+     * option configuration names defined by the {@code option.[name]}
+     * declarations.
+     *
+     * @return the non-{@code null}, non-empty option map (note that if no
+     * option configurations are defined when parsing an exception will be
+     * thrown.
+     */
+    public Map<String, OptionConfiguration> getOptionConfigurations()
+    {
+        return Collections.unmodifiableMap(optionMap);
+    }
+
+    /**
+     * Get the options type for this global configuration.
+     *
+     * @return the options type; may be {@code null}.
+     */
+    public OptionsTypeEnum getOptionsType()
+    {
+        return optionsType;
+    }
+
+    /**
+     * Set the options type for this global configuration.
+     *
+     * @param optionsType the options type.
+     */
+    public void setOptionsType(OptionsTypeEnum optionsType)
+    {
+        this.optionsType = optionsType;
+    }
+
+    /**
+     * Parse the option type.
+     *
+     * @param data data containing the option type - one of
+     * {@link #GLOBAL_OPTION_TYPE_SHORT}, {@link #GLOBAL_OPTION_TYPE_LONG}, or
+     * {@link #GLOBAL_OPTION_TYPE_BOTH}.
+     *
+     * @throws ConfigurationException if the global options type has already been set,
+     * or if the options type did not match a known type.
+     */
+    private void parseOptionType(String data) throws ConfigurationException
+    {
+        if (getOptionsType() != null)
+        {
+            throw new ConfigurationException(OPTION_TYPE
+                    + " has already been defined as "
+                    + getOptionsType().getType()
+                    + " but found second definition: " + data);
+        }
+        if (OptionsTypeEnum.BOTH.getType().equals(data))
+        {
+            setOptionsType(OptionsTypeEnum.BOTH);
+        }
+        else if (OptionsTypeEnum.SHORT.getType().equals(data))
+        {
+            setOptionsType(OptionsTypeEnum.SHORT);
+        }
+        else if (OptionsTypeEnum.LONG.getType().equals(data))
+        {
+            setOptionsType(OptionsTypeEnum.LONG);
+        }
+        else
+        {
+            throw new ConfigurationException("Unknown options type: " + data);
+        }
+    }
+
+    /**
+     * Parses global configurations that begin with {@code HELP_}.
+     *
+     * @param line non-{@code null} line to parse.
+     */
+    private void parseHelp(final String line) throws ConfigurationException
+    {
+        String[] data = line.split("=");
+        if (GlobalConfiguration.HELP_COMMAND_NAME.equals(data[0].trim()))
+        {
+            helpCommandName = data[1].trim();
+        }
+        else if (GlobalConfiguration.HELP_COMMAND_HEADER.equals(data[0].trim()))
+        {
+            helpCommandHeader = data[1].trim();
+        }
+        else if (GlobalConfiguration.HELP_COMMAND_FOOTER.equals(data[0].trim()))
+        {
+            helpCommandFooter = data[1].trim();
+        }
+        else if (GlobalConfiguration.HELP_OPTION_NAME.equals(data[0].trim()))
+        {
+            helpOptionName = data[1].trim();
+        }
+        else
+        {
+            throw new ConfigurationException("Unknown help configuration: " + line);
+        }
+    }
+}

--- a/src/main/java/org/apache/commons/cli/config/OptionConfiguration.java
+++ b/src/main/java/org/apache/commons/cli/config/OptionConfiguration.java
@@ -1,0 +1,270 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+/**
+ * Contains information from a set of properties of the form
+ * {@code option.[name].*}. The following option values are supported:
+ *
+ * <ul>
+ * <li>{@code option.[name].opts=[options]}: specify short and long options, a
+ * short option or a long option. For the first form, a single character is
+ * specified for the short option followed by a forward slash, followed by a
+ * text string of at least two characters for the long option. For the second
+ * form, a single character is specified for the short option. For the final
+ * form, text of at least two characters is specified for the long option. This
+ * is the only required configuration option.
+ *
+ * <p>
+ * If the {@link GlobalConfiguration} {@code OPTION_TYPE} is not defined, all
+ * defined options must take the same form, otherwise an exception will the
+ * thrown. if the global configuration is defined then all options must conform
+ * to that type;
+ * </li>
+ * <li>{@code option.[name].hasArg=[true|false]}: if {@code true} then the
+ * argument will be supplied with a value via the command line; otherwise the
+ * option will not require a value. By default, this is {@code false} so is not
+ * required for options that do not require arguments although can be supplied
+ * for clarity;</li>
+ * <li>{@code option.[name].argName=[argName]}: used when displaying help. By
+ * default, this configuration is not required;</li>
+ * <li>{@code option.[name].description=[description]}: used when displaying
+ * help. By default this configuration is not required.</li>
+ * </ul>
+ *
+ * <p>
+ * The {@code [name]} section of the option is the name that
+ * {@link OptionListener}s will receive an update for via the {@code option}
+ * parameter via
+ * {@link OptionListener#option(java.lang.String, java.lang.Object)}; if the the
+ * argument's {@code hasArg} is {@code true}, then the {@code value} will be the
+ * value supplied via the command line; for arguments that have {@code hasArg}
+ * as {@code false}, {@code value} will be {@code null}.
+ *
+ * <p>
+ * Lines beginning with &#35; are ignored.
+ * 
+ * <p>
+ * For example, a configuration file named {@code opt.config} could be created
+ * with the following option configuration (note that typically, creators of
+ * configurations will likely have the {@code name} and the long option text
+ * using the same text, although here they are different to add clarity to how
+ * the {@link OptionListener} is updated):
+ *
+ * <pre>
+ * option.outfile.opts=f/file
+ * option.outfile.hasArg=true
+ * option.outfile.argName=file
+ * option.outfile.description=File to write to.
+ *
+ * option.textToWrite.opts=t/text
+ * option.textToWrite.hasArg=true
+ * option.textToWrite.argName=text
+ * option.textToWrite.description=Text to write to the file.
+ *
+ * option.writeover.opts=o/overwrite
+ * # We do not need to specify this since all options are false for hasArg if not specified
+ * # option.writeover.hasArg=false
+ * option.writeover.description=If set, write over the existing file; \
+ *      otherwise, append to the file.
+ *
+ * option.showHelp.opts=h/help
+ * option.showHelp.hasArg=false
+ * option.showHelp.description=Print this help then quit.
+ * </pre>
+ *
+ * <p>
+ * ... When parsed by the {@link CommandLineConfiguration} with the value
+ * {@code --file datafile.txt} would update all registered
+ * {@link OptionListener}s via
+ * {@link OptionListener#option(java.lang.String, java.lang.Object)} and would
+ * receive an update with the option {@code file} given a value of
+ * {@code datafile.txt}.
+ *
+ * <p>
+ * In all cases, lines may be escaped; escaped lines must end in a trailing
+ * backslash character; lines to be appended must be indented using white space
+ * (space character and/or tab characters). This is especially useful when
+ * defining help descriptions. For example:
+ *
+ * <pre>
+ * option.file.description=Supply the output file to write results to. If the \
+ *      file doesn't exist, it is created. If the file does exist, it is
+ *      appended to.
+ * </pre>
+ *
+ * Note in the above example the spaces before the backslashes - this is so
+ * sentences are not 'glued' together and provide spacing that is easy on the
+ * eye to readers of the output.
+ */
+public class OptionConfiguration
+{
+
+    /**
+     * The name of the property; this is the name as it appears in the
+     * configuration after the {@code option.} declaration.
+     */
+    private String name;
+
+    /**
+     * The description for the option that will be displayed when help is
+     * displayed.
+     */
+    private String description;
+
+    /**
+     * The short-form option of the CLI declaration.
+     */
+    private String shortOption;
+
+    /**
+     * The long-form option of the CLI declaration.
+     */
+    private String longOption;
+
+    /**
+     * The argument name (if required).
+     */
+    private String argName;
+
+    /**
+     * Determines if this option configuration has an argument.
+     */
+    private boolean hasArg;
+
+    /**
+     * Get the name.
+     *
+     * @return the name.
+     */
+    public String getName()
+    {
+        return name;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name.
+     */
+    public void setName(final String name)
+    {
+        this.name = name;
+    }
+
+    /**
+     * Get the description.
+     *
+     * @return the description.
+     */
+    public String getDescription()
+    {
+        return description;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description.
+     */
+    public void setDescription(final String description)
+    {
+        this.description = description;
+    }
+
+    /**
+     * Get the short option.
+     *
+     * @return the short option.
+     */
+    public String getShortOption()
+    {
+        return shortOption;
+    }
+
+    /**
+     * Set the short option.
+     *
+     * @param shortOption the short option.
+     */
+    public void setShortOption(final String shortOption)
+    {
+        this.shortOption = shortOption;
+    }
+
+    /**
+     * Get the long option.
+     *
+     * @return the long option.
+     */
+    public String getLongOption()
+    {
+        return longOption;
+    }
+
+    /**
+     * Set the long option.
+     *
+     * @param longOption the long option.
+     */
+    public void setLongOption(String longOption)
+    {
+        this.longOption = longOption;
+    }
+
+    /**
+     * Get the argument name.
+     *
+     * @return the argument name.
+     */
+    public String getArgName()
+    {
+        return argName;
+    }
+
+    /**
+     * Set the argument name.
+     *
+     * @param argName the argument name.
+     */
+    public void setArgName(final String argName)
+    {
+        this.argName = argName;
+    }
+
+    /**
+     * Determine if this option has an argument.
+     *
+     * @return {@code true} if the option takes an argument; {@code false}
+     * otherwise.
+     */
+    public boolean hasArg()
+    {
+        return hasArg;
+    }
+
+    /**
+     * Set that the option has an argument.
+     *
+     * @param hasArg {@code true} if the option takes an argument; {@code false}
+     * otherwise.
+     */
+    public void setHasArg(final boolean hasArg)
+    {
+        this.hasArg = hasArg;
+    }
+}

--- a/src/main/java/org/apache/commons/cli/config/OptionListener.java
+++ b/src/main/java/org/apache/commons/cli/config/OptionListener.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+/**
+ * Listener for receiving updates from the process of parsing a option
+ * configuration.
+ *
+ * <p>
+ * An example option configuration is defined in {@link OptionConfiguration} and
+ * how this is processed is explained in {@link CommandLineConfiguration}. Once
+ * the call to
+ * {@link CommandLineConfiguration#process(java.io.InputStream, java.lang.String[])}
+ * has been invoked, all registered listeners will have received all necessary
+ * updates from the command line. All that is left to do now is do something
+ * useful with the supplied arguments.
+ *
+ * <p>
+ * In the following example, updating of the options and then doing something
+ * with them is all dealt with in the {@link OptionListener}; however in
+ * principle this can easily be split into different classes such that the
+ * {@link OptionListener} contains the values updated via the command line which
+ * a separate class then utilises to do something useful with.
+ *
+ * <p>
+ * Continuing from the configuration defined in {@link OptionConfiguration} and
+ * the call to process the file defined in {@link CommandLineConfiguration},
+ * let's take a look at an example implementation of {@code MyAppListener}
+ * within the {@code option(String, Object)} method - members are {@code public}
+ * so that once processing of arguments is complete, external classes can obtain
+ * the values read from the command line:
+ * <pre>
+ * public File outFile;
+ *
+ * public String text;
+ *
+ * public boolean overwrite;
+ *
+ * &#064;Override
+ * public void option(final String option, final Object value)
+ * {
+ *     if ("file".equals(option))
+ *     {
+ *         outFile = new File(value.toString());
+ *     }
+ *     else if ("text".equals(option))
+ *     {
+ *         text = value.toString();
+ *     }
+ *     else if ("overwrite".equals(option))
+ *     {
+ *         overwrite = true;
+ *     }
+ *  }
+ * </pre>
+ *
+ * <p>
+ * Note that since the example option configuration defines both short and long
+ * options, the listener will still receive an update in the above code for the
+ * {@code "file".equals(option)} test even if the user specified {@code -f} via
+ * the command line. Therefore it is up to listeners of configurations of both
+ * short and long options to decide which to cater for; in general long options
+ * aid readability in source files compared to single characters.
+ */
+public interface OptionListener
+{
+
+    /**
+     * Update with the specified option and it's value (if it has one). Note
+     * that the option will be a short option if only short options are defined,
+     * a long option if only long options are defined, or both if both short and
+     * long options are defined. In the latter case listeners will receive two
+     * updates and can decide which form to cater for; in general long options
+     * aid readability in source files compared to single characters.
+     *
+     * @param option non-{@code null} option, either in short form or long form.
+     *
+     * @param value the value of the argument; for options that do not have an
+     * argument, the value will be {@code null}.
+     */
+    void option(final String option, final Object value);
+}

--- a/src/main/java/org/apache/commons/cli/config/OptionsTypeEnum.java
+++ b/src/main/java/org/apache/commons/cli/config/OptionsTypeEnum.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+/**
+ * Defines if the configuration takes a short, long or both options.
+ * @author rich
+ */
+public enum OptionsTypeEnum
+{
+
+    /**
+     * Both options used - short and long.
+     */
+    BOTH("BOTH"),
+    /**
+     * Short options only.
+     */
+    SHORT("SHORT"),
+    /**
+     * Long options only.
+     */
+    LONG("LONG");
+
+    /**
+     * One of BOTH, SHORT or LONG.
+     */
+    private final String type;
+
+    /**
+     * Create a new options type.
+     *
+     * @param type the name of the options type.
+     */
+    private OptionsTypeEnum(final String type)
+    {
+        this.type = type;
+    }
+
+    /**
+     * Get the type of the option.
+     *
+     * @return the option type.
+     */
+    public String getType()
+    {
+        return type;
+    }
+}

--- a/src/main/java/org/apache/commons/cli/config/package-info.java
+++ b/src/main/java/org/apache/commons/cli/config/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Apache Commons CLI config provides a means to reducing the amount of code written by defining CLI options via a configuration file.
+ */
+package org.apache.commons.cli.config;
+

--- a/src/test/java/org/apache/commons/cli/config/AbstractTestConfig.java
+++ b/src/test/java/org/apache/commons/cli/config/AbstractTestConfig.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ */
+public abstract class AbstractTestConfig
+{
+
+    /**
+     *
+     */
+    private final Map<String, String> options = new HashMap<String, String>();
+
+    /**
+     *
+     * @return
+     */
+    public Map<String, String> getOptions()
+    {
+        return Collections.unmodifiableMap(options);
+    }
+
+    /**
+     *
+     * @param option
+     * @param value
+     * @return
+     */
+    public String addOption(String option, String value)
+    {
+        return options.put(option, value);
+    }
+}

--- a/src/test/java/org/apache/commons/cli/config/CommandLineConfigurationTest.java
+++ b/src/test/java/org/apache/commons/cli/config/CommandLineConfigurationTest.java
@@ -1,0 +1,415 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.List;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.UnrecognizedOptionException;
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+
+/**
+ *
+ */
+public class CommandLineConfigurationTest
+{
+
+    /**
+     *
+     * @throws Exception
+     */
+    @Before
+    public void setUp() throws Exception
+    {
+        System.setSecurityManager(new NoExitSecurityManager());
+    }
+
+    /**
+     *
+     * @throws Exception
+     */
+    @After
+    public void tearDown() throws Exception
+    {
+        System.setSecurityManager(null); // or save and restore original
+    }
+
+    /**
+     * Test that once the configuration is parsed, the command line
+     * configuration is created with the specified arguments and the listener
+     * has been updated with the values specified by the CLI call. Since the
+     * configuration is of type 'both' because options are specified as
+     * char/string, we expect both short and long options to have been updated
+     * in the listener.
+     */
+    @Test
+    public void testProcessShortAndLongOptions() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_001_short_and_long_options.conf");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "-F -h 192.168.1.2 -p 80 -P /tmp".split(" ");
+        cliConfig.process(is, arguments);
+        // short options:
+        assertEquals("80", listener.getOptions().get("p"));
+        assertEquals("192.168.1.2", listener.getOptions().get("h"));
+        assertEquals("/tmp", listener.getOptions().get("P"));
+        assertTrue(listener.getOptions().containsKey("F"));
+        // long options:
+        assertEquals("80", listener.getOptions().get("port"));
+        assertEquals("192.168.1.2", listener.getOptions().get("host"));
+        assertEquals("/tmp", listener.getOptions().get("path"));
+        assertTrue(listener.getOptions().containsKey("fail"));
+    }
+
+    /**
+     * Test of removeOptionListener method, ensuring the listener is not updated
+     * once the process is invoked.
+     */
+    @Test
+    public void testRemoveOptionListener() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_001_short_and_long_options.conf");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "-F -h 192.168.1.2 -p 80 -P /tmp".split(" ");
+        cliConfig.removeOptionListener(listener);
+        cliConfig.process(is, arguments);
+        // short options:
+        assertEquals(null, listener.getOptions().get("p"));
+        assertEquals(null, listener.getOptions().get("h"));
+        assertEquals(null, listener.getOptions().get("P"));
+        assertFalse(listener.getOptions().containsKey("F"));
+        // long options:
+        assertEquals(null, listener.getOptions().get("port"));
+        assertEquals(null, listener.getOptions().get("host"));
+        assertEquals(null, listener.getOptions().get("path"));
+        assertFalse(listener.getOptions().containsKey("fail"));
+    }
+
+    /**
+     * Test that once the configuration is parsed, the command line
+     * configuration is created with the specified arguments and the listener
+     * has been updated with the values specified by the CLI call. Since the
+     * configuration is of type 'short' because options are specified as a char,
+     * we expect only short options to have been updated in the listener.
+     */
+    @Test
+    public void testProcessShortOptionsConfig() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_002_short_options.conf");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "-F -h 192.168.1.2 -p 80 -P /tmp".split(" ");
+        cliConfig.process(is, arguments);
+        // short options:
+        assertEquals("80", listener.getOptions().get("p"));
+        assertEquals("192.168.1.2", listener.getOptions().get("h"));
+        assertEquals("/tmp", listener.getOptions().get("P"));
+        assertTrue(listener.getOptions().containsKey("F"));
+        // these long options should not be set:
+        assertEquals(null, listener.getOptions().get("port"));
+        assertEquals(null, listener.getOptions().get("host"));
+        assertEquals(null, listener.getOptions().get("path"));
+        assertFalse(listener.getOptions().containsKey("fail"));
+    }
+
+    /**
+     * Test that once the configuration is parsed, the command line
+     * configuration is created with the specified arguments and the listener
+     * has been updated with the values specified by the CLI call. Since the
+     * configuration is of type 'long' because options are specified as a
+     * string, we expect only long options to have been updated in the listener.
+     */
+    @Test
+    public void testProcessLongOptionsConfig() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_003_long_options.conf");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "--fail --host 192.168.1.2 --port 80 --path /tmp".split(" ");
+        cliConfig.process(is, arguments);
+        // long options:
+        assertEquals("80", listener.getOptions().get("port"));
+        assertEquals("192.168.1.2", listener.getOptions().get("host"));
+        assertEquals("/tmp", listener.getOptions().get("path"));
+        assertTrue(listener.getOptions().containsKey("fail"));
+        // these short options should not be set:
+        assertEquals(null, listener.getOptions().get("p"));
+        assertEquals(null, listener.getOptions().get("h"));
+        assertEquals(null, listener.getOptions().get("P"));
+        assertFalse(listener.getOptions().containsKey("F"));
+    }
+
+    /**
+     * Test that once the configuration is parsed, the command line
+     * configuration is created with the specified arguments and the listener
+     * has been updated with the values specified by the CLI call. Since the
+     * configuration is of type 'both' because options are specified as
+     * char/string, we expect both short and long options to have been updated
+     * in the listener.
+     */
+    @Test
+    public void testGetOptions() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_001_short_and_long_options.conf");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "-F -h 192.168.1.2 -p 80 -P /tmp".split(" ");
+        cliConfig.process(is, arguments);
+        List<Option> options = cliConfig.getOptions();
+        // short options:
+        assertEquals("80", getOptionValue(options, "p"));
+        assertEquals("192.168.1.2", getOptionValue(options, "h"));
+        assertEquals("/tmp", getOptionValue(options, "P"));
+        assertNotNull(getOptionValue(options, "F"));
+    }
+
+    /**
+     * Test of process method, ensuring that when an unknown option is provided,
+     * the appropriate exception is thrown.
+     */
+    @Test
+    public void testProcessFailsParseException() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_001_short_and_long_options.conf");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "--no-such-option -F -h 192.168.1.2".split(" ");
+        try
+        {
+            cliConfig.process(is, arguments);
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Unrecognized option"));
+            assertEquals(UnrecognizedOptionException.class,
+                    ex.getCause().getClass());
+        }
+    }
+
+    /**
+     * Test that invoking help prints the help then quits with exit status 0.
+     */
+    @Test
+    public void testProcessPrintHelpShortOption() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_015_print_short_option_help.csv");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "-h".split(" ");
+        try
+        {
+            cliConfig.process(is, arguments);
+            fail("Expected system exit, but got here");
+        }
+        catch (ExitException ex)
+        {
+            assertEquals(0, ex.status);
+            assertEquals("Exiting with status " + ex.status, ex.getMessage());
+        }
+    }
+
+    /**
+     * Test that specifying auto-print help via the command line configuration
+     * without the arguments containing the help option does not print the help.
+     */
+    @Test
+    public void testProcessDoesNotPrintHelp() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_015_print_short_option_help.csv");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "-f -H localhost".split(" ");
+        try
+        {
+            cliConfig.process(is, arguments);
+        }
+        catch (ExitException ex)
+        {
+            fail("System exit invoked, but no request to print help specified."
+                    + " Something has gone wrong!");
+        }
+    }
+
+    /**
+     * Test that invoking help prints the help then quits with exit status 0.
+     */
+    @Test
+    public void testProcessPrintHelpLongOption() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_016_print_long_option_help.csv");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "--help".split(" ");
+        try
+        {
+            cliConfig.process(is, arguments);
+            fail("Expected system exit, but got here");
+        }
+        catch (ExitException ex)
+        {
+            assertEquals(0, ex.status);
+            assertEquals("Exiting with status " + ex.status, ex.getMessage());
+        }
+    }
+
+    /**
+     * Test that invoking help when hasArg = true throws an error.
+     */
+    @Test
+    public void testProcessPrintHelpHasArgThrowsError() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_017_bad_help_option.csv");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "--help foobarbaz".split(" ");
+        try
+        {
+            cliConfig.process(is, arguments);
+            fail("Expected exception");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertEquals("Error: Option help cannot have an argument"
+                    + " associated with it.", ex.getMessage());
+        }
+    }
+
+    /**
+     * Test that the specified header and footer are included.
+     */
+    @Test
+    public void testHelpHeaderFooter() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_018_header_and_footer.csv");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "--help".split(" ");
+
+        try
+        {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(os);
+            System.setOut(ps);
+            cliConfig.process(is, arguments);
+            String output = os.toString("UTF8");
+            assertTrue(output.contains("foo_command"));
+            assertTrue(output.contains("Show some useful information"));
+            assertTrue(output.contains("Copyright Apache Software Foundation"));
+            fail("Expected system exit, but got here");
+        }
+        catch (ExitException ex)
+        {
+            assertEquals(0, ex.status);
+            assertEquals("Exiting with status " + ex.status, ex.getMessage());
+        }
+    }
+
+    /**
+     * Test that the specified escaped header and footer are included.
+     */
+    @Test
+    public void testHelpHeaderFooterEscaped() throws Exception
+    {
+        ConfigListener listener = new ConfigListener();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_019_header_and_footer_escaped.csv");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(listener);
+        String[] arguments = "--help".split(" ");
+
+        try
+        {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(os);
+            System.setOut(ps);
+            cliConfig.process(is, arguments);
+            String output = os.toString("UTF8");
+            assertTrue(output.contains("foo_command"));
+            assertTrue(output.contains("Show some useful information, with some"
+                    + " extra escaped lines"));
+            assertTrue(output.contains("Copyright Apache Software Foundation"
+                    + " Submit escaped lines to System.out()"));
+            fail("Expected system exit, but got here");
+        }
+        catch (ExitException ex)
+        {
+            assertEquals(0, ex.status);
+            assertEquals("Exiting with status " + ex.status, ex.getMessage());
+        }
+    }
+
+    /**
+     * Get the option value from the list where the option name equals the
+     * specified key.
+     *
+     * @param options non-{@code null}, non-empty option list.
+     * 
+     * @param key non-{@code null} key to search for.
+     * 
+     * @return the option value if it could be retrieved, or the empty string
+     * if the option does not have an argument; {@code null} otherwise.
+     */
+    private String getOptionValue(final List<Option> options, String key)
+    {
+        String result = null;
+        for (Option option : options)
+        {
+            if (key.equals(option.getOpt()))
+            {
+                if (option.hasArg())
+                {
+                    result = option.getValue();
+                }
+                else
+                {
+                    result = "";
+                }
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/test/java/org/apache/commons/cli/config/ConfigListener.java
+++ b/src/test/java/org/apache/commons/cli/config/ConfigListener.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+/**
+ * Class for test classes to utilise; they add this listener before they make
+ * any calls to
+ * {@link CommandLineConfig#process(java.io.InputStream, java.lang.String[])}
+ * and interrogate this listener using {@link AbstractTestConfig#getOptions()}
+ * after processing has occurred, to determine that the specified values were
+ * registered during the parsing process.
+ */
+public class ConfigListener extends AbstractTestConfig
+        implements OptionListener
+{
+
+    /**
+     * Callers implementing this would normally set members or take actions when
+     * receiving updates.
+     *
+     * @param option non-{@code null} command line option updated from the
+     * result of the command line parsing process.
+     * 
+     * @param value value of the command line value, if the command line option
+     * has an argument; {@code null} otherwise (and implies the command line
+     * option does not have an argument).
+     */
+    @Override
+    public void option(String option, Object value)
+    {
+        String optValue = null;
+        if (value != null)
+        {
+            optValue = value.toString();
+            /*
+             e.g. 
+             if ("host".equals(option)) {
+             server.setHostname(optValue);
+             }
+             */
+        }
+        /*
+         Else if value is false, implies option doesn't have an argument, e.g
+        
+         if ("fail".equals(option)) {
+         server.setFail(true);
+         }
+         */
+        addOption(option, optValue);
+    }
+
+}

--- a/src/test/java/org/apache/commons/cli/config/ConfigurationParserTest.java
+++ b/src/test/java/org/apache/commons/cli/config/ConfigurationParserTest.java
@@ -1,0 +1,525 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import static org.apache.commons.cli.config.GlobalConfiguration.OPTION_TYPE;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class ConfigurationParserTest
+{
+
+    public ConfigurationParserTest()
+    {
+    }
+
+    @BeforeClass
+    public static void setUpClass()
+    {
+    }
+
+    @AfterClass
+    public static void tearDownClass()
+    {
+    }
+
+    @Before
+    public void setUp()
+    {
+    }
+
+    @After
+    public void tearDown()
+    {
+    }
+
+    /**
+     * Test of parse method, of class ConfigurationParser.
+     */
+    @Test
+    public void testParseOpts() throws Exception
+    {
+        String text = "option.fail.opts=F/fail";
+        Pattern p = Pattern.compile(ConfigurationParser.OPTION_REGEX_BASIC_LINE);
+        Matcher m = p.matcher(text);
+        assertTrue(m.matches());
+        assertEquals("fail", m.group(1));
+        assertEquals("opts", m.group(2));
+        assertEquals("F/fail", m.group(3));
+    }
+
+    /**
+     * Test of parse method, of class ConfigurationParser.
+     */
+    @Test
+    public void testParseHasArg() throws Exception
+    {
+        String text = "option.fail.hasArg=true";
+        Pattern p = Pattern.compile(ConfigurationParser.OPTION_REGEX_BASIC_LINE);
+        Matcher m = p.matcher(text);
+        assertTrue(m.matches());
+        assertEquals("fail", m.group(1));
+        assertEquals("hasArg", m.group(2));
+        assertEquals("true", m.group(3));
+    }
+
+    /**
+     * Test of parse method, of class ConfigurationParser.
+     */
+    @Test
+    public void testParseDescription() throws Exception
+    {
+        String text = "option.fail.description=fail gracefully.";
+        Pattern p = Pattern.compile(ConfigurationParser.OPTION_REGEX_BASIC_LINE);
+        Matcher m = p.matcher(text);
+        assertTrue(m.matches());
+        assertEquals("fail", m.group(1));
+        assertEquals("description", m.group(2));
+        assertEquals("fail gracefully.", m.group(3));
+    }
+
+    /**
+     * Test of parse method, of class ConfigurationParser.
+     */
+    @Test
+    public void testParseDescriptionEscaped() throws Exception
+    {
+        String text = "option.fail.description=fail gracefully, \\";
+        Pattern p = Pattern.compile(ConfigurationParser.OPTION_REGEX_BASIC_LINE);
+        Matcher m = p.matcher(text);
+        assertTrue(m.matches());
+        assertEquals("fail", m.group(1));
+        assertEquals("description", m.group(2));
+        assertEquals("fail gracefully, \\", m.group(3));
+    }
+
+    /**
+     * Test of parse method, of class ConfigurationParser.
+     */
+    @Test
+    public void testParseInputStream() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_001_short_and_long_options.conf");
+        GlobalConfiguration globalConfig = configParser.parse(is);
+        Map<String, OptionConfiguration> optionConfig = globalConfig.getOptionConfigurations();
+        is.close();
+        OptionConfiguration optConfig = optionConfig.get("fail");
+        checkOptionConfiguration(optConfig, "fail", "F", "fail",
+                "Fail if no connection made, rather than retrying.", false);
+        optConfig = optionConfig.get("host");
+        checkOptionConfiguration(optConfig, "host", "h", "host",
+                "Specify the host; optional. Use localhost if not set."
+                + " Protocol is optional, assumes HTTP.", true);
+        optConfig = optionConfig.get("port");
+        checkOptionConfiguration(optConfig, "port", "p", "port",
+                "Port number to use. Required.", true);
+        optConfig = optionConfig.get("path");
+        checkOptionConfiguration(optConfig, "path", "P", "path",
+                "Comma separated list of paths to test on the server."
+                + " If spaces are contained within the arguments, surround with"
+                + " double quotes. Have as many lines as required, so long as"
+                + " they are escaped.", true);
+    }
+
+    /**
+     * Test of parse method, of class ConfigurationParser.
+     */
+    @Test
+    public void testParseInputStreamShortOption() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_002_short_options.conf");
+        GlobalConfiguration globalConfig = configParser.parse(is);
+        Map<String, OptionConfiguration> optionConfig = globalConfig.getOptionConfigurations();
+        is.close();
+        OptionConfiguration optConfig = optionConfig.get("fail");
+        checkOptionConfiguration(optConfig, "fail", "F", null,
+                "Fail if no connection made, rather than retrying.", false);
+        optConfig = optionConfig.get("host");
+        checkOptionConfiguration(optConfig, "host", "h", null,
+                "Specify the host; optional. Use localhost if not set."
+                + " Protocol is optional, assumes HTTP.", true);
+        optConfig = optionConfig.get("port");
+        checkOptionConfiguration(optConfig, "port", "p", null,
+                "Port number to use. Required.", true);
+        optConfig = optionConfig.get("path");
+        checkOptionConfiguration(optConfig, "path", "P", null,
+                "Comma separated list of paths to test on the server."
+                + " If spaces are contained within the arguments, surround with"
+                + " double quotes. Have as many lines as required, so long as"
+                + " they are escaped.", true);
+    }
+
+    /**
+     * Test of parse method, of class ConfigurationParser.
+     */
+    @Test
+    public void testParseInputStreamLongOption() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_003_long_options.conf");
+        GlobalConfiguration globalConfig = configParser.parse(is);
+        Map<String, OptionConfiguration> optionConfig = globalConfig.getOptionConfigurations();
+        is.close();
+        OptionConfiguration optConfig = optionConfig.get("fail");
+        checkOptionConfiguration(optConfig, "fail", null, "fail",
+                "Fail if no connection made, rather than retrying.", false);
+        optConfig = optionConfig.get("host");
+        checkOptionConfiguration(optConfig, "host", null, "host",
+                "Specify the host; optional. Use localhost if not set."
+                + " Protocol is optional, assumes HTTP.", true);
+        optConfig = optionConfig.get("port");
+        checkOptionConfiguration(optConfig, "port", null, "port",
+                "Port number to use. Required.", true);
+        optConfig = optionConfig.get("path");
+        checkOptionConfiguration(optConfig, "path", null, "path",
+                "Comma separated list of paths to test on the server."
+                + " If spaces are contained within the arguments, surround with"
+                + " double quotes. Have as many lines as required, so long as"
+                + " they are escaped.", true);
+    }
+
+    /**
+     * Test that an invalid mix of characters when not using option type BOTH
+     * (so having a separate long option and short option) throws an exception.
+     */
+    @Test
+    public void testParseInputStreamBadOptionMix() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_004_bad_short_long_mix.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Configuration type specifies"
+                    + " OPTION_TYPE as LONG but found SHORT"));
+        }
+    }
+
+    /**
+     * Test that empty opts value throws an exception.
+     */
+    @Test
+    public void testParseInputStreamZeroLengthOption() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_005_empty_opts_value.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Empty option value; must be a"
+                    + " non-zero length string"));
+        }
+    }
+
+    /**
+     * Test that having no options at all throws an exception.
+     */
+    @Test
+    public void testParseInputStreamNoOptionsAtAll() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_006_no_options.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("The configuration file"
+                    + " contained no options to parse"));
+        }
+    }
+
+    /**
+     * Test that an unknown sub-option throws an exception.
+     */
+    @Test
+    public void testParseInputStreamBadSubOptionName() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_007_unknown_config_option.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains(
+                    "Unknown configuration option: "));
+        }
+    }
+
+    /**
+     * Test that having no white space at the start of a succeeding line
+     * following in from an escaped line throws an exception.
+     */
+    @Test
+    public void testParseInputStreamBadEscapedLine() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_008_invalid_escaped_line.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Invalid escaped line: "));
+        }
+    }
+
+    /**
+     * Test that using type BOTH when not formatted correctly throws an
+     * exception.
+     */
+    @Test
+    public void testParseInputStreamBadLongShortOptionFormat() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_009_invalid_short_long_format.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Invalid short and"
+                    + " long option format; must be [character]/"
+                    + " [text] but found "));
+        }
+    }
+
+    /**
+     * Test that an invalid character for opts throws an exception for SHORT
+     * option.
+     */
+    @Test
+    public void testParseInputStreamBadShortOptionFormat() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_010_invalid_short_format.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Expected single"
+                    + " character for short option but found "));
+        }
+    }
+
+    /**
+     * Test that invalid characters for LONG option fails.
+     */
+    @Test
+    public void testParseInputStreamBadLongOptionFormat() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_011_invalid_long_option_format.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Expected text"
+                    + " for long option but found "));
+        }
+    }
+
+    /**
+     * Test that completely invalid option throws an exception.
+     */
+    @Test
+    public void testParseInputStreamBadLineOptionFormat() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_012_invalid_option_definition.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Invalid option definition: "));
+        }
+    }
+
+    /**
+     * Test that when the user defines a correct option, if a succeeding option
+     * contains an empty name, the error message will also inform them of what
+     * option type they're using (short, long, both).
+     */
+    @Test
+    public void testParseInputStreamZeroLength2ndOption() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_013_empty_option_value.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Empty option value; must be a"
+                    + " non-zero length string; global configuration is defined as "));
+        }
+    }
+
+    /**
+     * Test that a repeated global option declaration throws the appropriate
+     * exception.
+     */
+    @Test
+    public void testParseInputStreamRepeatedGlobalConfig() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_014_option_type_defined_twice.conf");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains(OPTION_TYPE
+                    + " has already been defined as "
+                    + OptionsTypeEnum.BOTH.getType()
+                    + " but found second definition: "
+                    + OptionsTypeEnum.BOTH.getType()));
+        }
+    }
+
+    /**
+     * Test that a global option defined after common "option." options throws
+     * an exception.
+     */
+    @Test
+    public void testParseInputStreamBadGlobalConfiguration() throws Exception
+    {
+        ConfigurationParser configParser = new ConfigurationParser();
+        InputStream is = ConfigurationParserTest.class.getResourceAsStream(
+                "/config/config_020_bad_global_config_order.csv");
+        try
+        {
+            configParser.parse(is);
+            fail("Expected exception.");
+        }
+        catch (ConfigurationException ex)
+        {
+            assertTrue(ex.getMessage().contains("Invalid global"
+                    + " configuration definition; global configurations"
+                    + " must come BEFORE standard \"option...\" definitions"));
+        }
+    }
+
+    /**
+     * Test of addOptionListener method, of class ConfigurationParser.
+     */
+    @Test
+    public void testAddOptionListener()
+    {
+
+    }
+
+    /**
+     * Test of removeOptionListener method, of class ConfigurationParser.
+     */
+    @Test
+    public void testRemoveOptionListener()
+    {
+
+    }
+
+    /**
+     * Check that the specified option configuration values match the other
+     * arguments passed in.
+     *
+     * @param optConfig non-{@code null} option configuration.
+     *
+     * @param optionName non-{@code null} name of the option to match.
+     *
+     * @param shortOption short option name to match; if {@code null}, implies
+     * using long options.
+     *
+     * @param longOption long option name to match; if {@code null}, implies
+     * using short options.
+     *
+     * @param descrption non-{@code null} description to match.
+     *
+     * @param hasArg match if the option has an argument or not.
+     */
+    private void checkOptionConfiguration(OptionConfiguration optConfig,
+            String optionName, String shortOption, String longOption,
+            String descrption, boolean hasArg)
+    {
+        assertNotNull(optConfig);
+        assertEquals(shortOption, optConfig.getShortOption());
+        assertEquals(longOption, optConfig.getLongOption());
+        assertEquals(optionName, optConfig.getName());
+        assertEquals(descrption, optConfig.getDescription());
+        assertEquals(hasArg, optConfig.hasArg());
+    }
+
+}

--- a/src/test/java/org/apache/commons/cli/config/ExitException.java
+++ b/src/test/java/org/apache/commons/cli/config/ExitException.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+/**
+ * Adapted from
+ * https://stackoverflow.com/questions/309396/java-how-to-test-methods-that-call-system-exit.
+ * 
+ * @see NoExitSecurityManager
+ */
+class ExitException extends SecurityException
+{
+
+    /**
+     * Exit status of the exception.
+     */
+    public final int status;
+
+    /**
+     * Create a new (system) exit exception.
+     * 
+     * @param status the exit status of the exception.
+     */
+    public ExitException(int status)
+    {
+        super("Exiting with status " + status);
+        this.status = status;
+    }
+}

--- a/src/test/java/org/apache/commons/cli/config/GlobalConfigurationTest.java
+++ b/src/test/java/org/apache/commons/cli/config/GlobalConfigurationTest.java
@@ -1,0 +1,227 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.commons.cli.config;
+
+import static org.apache.commons.cli.config.GlobalConfiguration.OPTION_TYPE;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class GlobalConfigurationTest
+{
+
+    /**
+     * Test of updateGlobalConfiguration method, of class GlobalConfiguration,
+     * for option type {@link GlobalConfiguration#GLOBAL_OPTION_TYPE_BOTH}.
+     */
+    @Test
+    public void testUpdateGlobalConfigurationOptionTypeBoth() throws Exception
+    {
+        final String data = GlobalConfiguration.OPTION_TYPE + "="
+                + OptionsTypeEnum.BOTH.getType();
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        globalConfig.updateGlobalConfiguration(data);
+        assertEquals(OptionsTypeEnum.BOTH, globalConfig.getOptionsType());
+    }
+
+    /**
+     * Test of updateGlobalConfiguration method, of class GlobalConfiguration,
+     * for option type {@link GlobalConfiguration#GLOBAL_OPTION_TYPE_SHORT}.
+     */
+    @Test
+    public void testUpdateGlobalConfigurationOptionTypeShort() throws Exception
+    {
+        final String data = GlobalConfiguration.OPTION_TYPE + "="
+                + OptionsTypeEnum.SHORT.getType();
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        globalConfig.updateGlobalConfiguration(data);
+        assertEquals(OptionsTypeEnum.SHORT, globalConfig.getOptionsType());
+    }
+
+    /**
+     * Test of updateGlobalConfiguration method, of class GlobalConfiguration,
+     * for option type {@link GlobalConfiguration#GLOBAL_OPTION_TYPE_LONG}.
+     */
+    @Test
+    public void testUpdateGlobalConfigurationOptionTypeLong() throws Exception
+    {
+        final String data = GlobalConfiguration.OPTION_TYPE + "="
+                + OptionsTypeEnum.LONG.getType();
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        globalConfig.updateGlobalConfiguration(data);
+        assertEquals(OptionsTypeEnum.LONG, globalConfig.getOptionsType());
+    }
+
+    /**
+     * Test of updateGlobalConfiguration method, of class GlobalConfiguration,
+     * for option type {@link GlobalConfiguration#GLOBAL_OPTION_TYPE_LONG}.
+     */
+    @Test
+    public void testUpdateGlobalConfigurationCommandFooter() throws Exception
+    {
+        final String data = GlobalConfiguration.HELP_COMMAND_FOOTER + "="
+                + "Some useful footer information";
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        globalConfig.updateGlobalConfiguration(data);
+        assertEquals("Some useful footer information", 
+                globalConfig.getHelpCommandFooter());
+    }
+
+    /**
+     * Test of updateGlobalConfiguration method, of class GlobalConfiguration,
+     * for option type {@link GlobalConfiguration#GLOBAL_OPTION_TYPE_LONG}.
+     */
+    @Test
+    public void testUpdateGlobalConfigurationCommandHeader() throws Exception
+    {
+        final String data = GlobalConfiguration.HELP_COMMAND_HEADER + "="
+                + "Some useful header information";
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        globalConfig.updateGlobalConfiguration(data);
+        assertEquals("Some useful header information", 
+                globalConfig.getHelpCommandHeader());
+    }
+
+    /**
+     * Test of updateGlobalConfiguration method, of class GlobalConfiguration,
+     * for option type {@link GlobalConfiguration#GLOBAL_OPTION_TYPE_LONG}.
+     */
+    @Test
+    public void testUpdateGlobalConfigurationOptionTypeUnknown() throws Exception
+    {
+        // The Good, the Bad and the Ugly: Unknown grave, Bill Carson:
+        final String data = GlobalConfiguration.OPTION_TYPE
+                + "=Bill Carson";
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        try
+        {
+            globalConfig.updateGlobalConfiguration(data);
+            fail("Expected an exception");
+        }
+        catch(ConfigurationException ex)
+        {
+            assertEquals(ex.getMessage(), "Unknown options type: Bill Carson");
+        }
+    }
+
+    /**
+     * Test of updateGlobalConfiguration method, of class GlobalConfiguration,
+     * for option type {@link GlobalConfiguration#GLOBAL_OPTION_TYPE_LONG}.
+     */
+    @Test
+    public void testUpdateGlobalConfigurationUnknownOptionType() throws Exception
+    {
+        // The Good, the Bad and the Ugly: Unknown grave, Bill Carson:
+        final String data = "BILL_CARSON=Bill Carson";
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        try
+        {
+            globalConfig.updateGlobalConfiguration(data);
+            fail("Expected an exception");
+        }
+        catch(ConfigurationException ex)
+        {
+            assertEquals(ex.getMessage(), 
+                    "Unknown global configuration declaration: BILL_CARSON");
+        }
+    }
+
+    /**
+     * Test of updateGlobalConfiguration method, testing that when a global
+     * option type is specified more than once, an error occurs.
+     */
+    @Test
+    public void testUpdateGlobalConfigurationReDefinedOptionType() throws Exception
+    {
+        // The Good, the Bad and the Ugly: Unknown grave, Bill Carson:
+        final String data = GlobalConfiguration.OPTION_TYPE + "="
+                + OptionsTypeEnum.BOTH.getType();
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        globalConfig.setOptionsType(OptionsTypeEnum.BOTH);
+        try
+        {
+            globalConfig.updateGlobalConfiguration(data);
+            fail("Expected an exception");
+        }
+        catch(ConfigurationException ex)
+        {
+            assertEquals(ex.getMessage(), OPTION_TYPE
+                    + " has already been defined as "
+                    + OptionsTypeEnum.BOTH.getType()
+                    + " but found second definition: "
+                    + OptionsTypeEnum.BOTH.getType());
+        }
+    }
+
+    /**
+     * Test of updateGlobalConfiguration method, testing that a badly named
+     * help option throws an exception
+     */
+    @Test
+    public void testUpdateGlobalConfigurationBadHelpOption() throws Exception
+    {
+        // The Good, the Bad and the Ugly: Unknown grave, Bill Carson:
+        final String data = "HELP_FOO=exception!";
+        GlobalConfiguration globalConfig = new GlobalConfiguration();
+        try
+        {
+            globalConfig.updateGlobalConfiguration(data);
+            fail("Expected an exception");
+        }
+        catch(ConfigurationException ex)
+        {
+            assertEquals(ex.getMessage(),
+                    "Unknown help configuration: HELP_FOO=exception!");
+        }
+    }
+
+    /**
+     * Test of addOptionConfiguration method, of class GlobalConfiguration.
+     */
+    @Test
+    public void testAddOptionConfiguration()
+    {
+    }
+
+    /**
+     * Test of getOptionConfigurations method, of class GlobalConfiguration.
+     */
+    @Test
+    public void testGetOptionMap()
+    {
+    }
+
+    /**
+     * Test of getOptionsType method, of class GlobalConfiguration.
+     */
+    @Test
+    public void testGetOptionsType()
+    {
+    }
+
+    /**
+     * Test of setOptionsType method, of class GlobalConfiguration.
+     */
+    @Test
+    public void testSetOptionsType()
+    {
+    }
+    
+}

--- a/src/test/java/org/apache/commons/cli/config/MainTester.java
+++ b/src/test/java/org/apache/commons/cli/config/MainTester.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+
+/**
+ *
+ */
+public class MainTester implements OptionListener
+{
+
+    private String md5;
+    private String file;
+
+    public static void main(String[] args) throws Exception
+    {
+        new MainTester(args);
+    }
+
+    public MainTester(final String[] args) throws Exception
+    {
+        InputStream is = MainTester.class.getResourceAsStream(
+                "/config/config_real.conf");
+//                "/config/config_real.csv");
+        CommandLineConfiguration cliConfig = new CommandLineConfiguration();
+        cliConfig.addOptionListener(this);
+        cliConfig.process(is, args);
+        if (md5 != null && file != null)
+        {
+            checkMd5();
+        }
+        else
+        {
+            System.err.println("Invalid arguments; try -h/--help");
+        }
+    }
+
+    @Override
+    public void option(String option, Object value)
+    {
+        if ("md5".equals(option))
+        {
+            md5 = value.toString();
+        }
+        if ("file".equals(option))
+        {
+            file = value.toString();
+        }
+    }
+
+    private void checkMd5() throws Exception
+    {
+        FileInputStream is = new FileInputStream(new File(file));
+        
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        byte[] buffer = new byte[0xFFFF];
+        for (int len = is.read(buffer); len != -1; len = is.read(buffer))
+        {
+            os.write(buffer, 0, len);
+        }
+        MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+        messageDigest.reset();
+        messageDigest.update(os.toString("UTF-8").getBytes());
+        byte[] digestData = messageDigest.digest();
+
+        BigInteger bigInt = new BigInteger(1, digestData);
+        String hashtext = bigInt.toString(16);
+        System.out.println("Digest of file: " + hashtext);
+        System.out.println("MATCHES: " + md5.equalsIgnoreCase(hashtext));
+    }
+}

--- a/src/test/java/org/apache/commons/cli/config/NoExitSecurityManager.java
+++ b/src/test/java/org/apache/commons/cli/config/NoExitSecurityManager.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.commons.cli.config;
+
+import java.security.Permission;
+
+/**
+ * Adapted from
+ * https://stackoverflow.com/questions/309396/java-how-to-test-methods-that-call-system-exit.
+ *
+ * One of the uses of the command line configuration is to auto-enable printing
+ * of help options, with the user only having to specify their help option via
+ * their arguments. Such a call invokes system exit with exit status 0; this
+ * class, along with {@link ExitException}, are used to catch this in the tests.
+ */
+class NoExitSecurityManager extends SecurityManager
+{
+
+    /**
+     * Allows anything.
+     * 
+     * @param perm not used.
+     */
+    @Override
+    public void checkPermission(Permission perm)
+    {
+        // allow anything.
+    }
+
+    /**
+     * Allows anything.
+     * 
+     * @param perm not used.
+     * 
+     * @param context not used.
+     */
+    @Override
+    public void checkPermission(final Permission perm, final Object context)
+    {
+        // allow anything.
+    }
+
+    /**
+     * Throws an {@link ExitException}.
+     * 
+     * @param status system exit status.
+     */
+    @Override
+    public void checkExit(int status)
+    {
+        super.checkExit(status);
+        throw new ExitException(status);
+    }
+}


### PR DESCRIPTION
Enable definition of command line arguments via configuration files. This reduces a lot of the code required to create CLI options. Javadoc and unit tests (100% coverage) updated, starting point for reading how to use configuration files is the class CommandLineConfiguration once the javadoc has been built. Developers are required to implement OptionListener in order to get updates.