### PR TITLE
added separate setter for Builder.opt

### DIFF
--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -789,7 +789,7 @@ public class Option implements Cloneable, Serializable
     public static final class Builder
     {
         /** the name of the option */
-        private final String opt;
+        private String opt;
 
         /** description of the option */
         private String description;
@@ -849,6 +849,16 @@ public class Option implements Cloneable, Serializable
         public Builder desc(final String description)
         {
             this.description = description;
+            return this;
+        }
+
+        /**
+         * Sets the name of the option
+         *
+         * @param opt name of the option
+         */
+        public Builder opt(String opt) {
+            this.opt = opt;
             return this;
         }
 

--- a/src/test/java/org/apache/commons/cli/OptionTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionTest.java
@@ -194,6 +194,8 @@ public class OptionTest
             "a", "desc", null, Option.UNINITIALIZED, null, false, false, ':', String.class);
         checkOption(Option.builder("a").desc("desc").type(Integer.class).build(),
             "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultSeparator, Integer.class);
+        checkOption(Option.builder().opt("a").desc("desc").build(),
+                "a", "desc", null, Option.UNINITIALIZED, null, false, false, defaultSeparator, String.class);
     }
 
     @Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
I would like to add (suggest) new setter method to set name of the option ('opt') in Option.Builder class outside of constructor.
So something like this would be allowed:
`Option.builder().opt("a")`
which would be equivalent to:
`Option.builder("a")`

Personally I find it more readable, maybe others will agree as well.