### PR TITLE
Make test files use Option.builder instead of deprecated OptionBuilder.

### DIFF
--- a/src/test/java/org/apache/commons/cli/ApplicationTest.java
+++ b/src/test/java/org/apache/commons/cli/ApplicationTest.java
@@ -49,11 +49,7 @@ public class ApplicationTest
         options.addOption( "a", "all", false, "do not hide entries starting with ." );
         options.addOption( "A", "almost-all", false, "do not list implied . and .." );
         options.addOption( "b", "escape", false, "print octal escapes for nongraphic characters" );
-        options.addOption( OptionBuilder.withLongOpt( "block-size" )
-                                        .withDescription( "use SIZE-byte blocks" )
-                                        .hasArg()
-                                        .withArgName("SIZE")
-                                        .create() );
+        options.addOption( Option.builder().longOpt("block-size").desc("use SIZE-byte blocks").hasArg().argName("SIZE").build() );
         options.addOption( "B", "ignore-backups", false, "do not list implied entried ending with ~");
         options.addOption( "c", false, "with -lt: sort by, and show, ctime (time of last modification of file status information) with -l:show ctime and sort by name otherwise: sort by ctime" );
         options.addOption( "C", false, "list entries by columns" );
@@ -83,11 +79,7 @@ public class ApplicationTest
         options.addOption( "logger", true, "the class which is to perform the logging" );
         options.addOption( "listener", true, "add an instance of a class as a project listener" );
         options.addOption( "buildfile", true, "use given buildfile" );
-        options.addOption( OptionBuilder.withDescription( "use value for given property" )
-                                        .hasArgs()
-                                        .withValueSeparator()
-                                        .create( 'D' ) );
-                           //, null, true, , false, true );
+        options.addOption( Option.builder("D").desc("use value for given property").hasArgs().valueSeparator().build() );
         options.addOption( "find", true, "search for buildfile towards the root of the filesystem and use it" );
 
         final String[] args = new String[]{ "-buildfile", "mybuild.xml",
@@ -114,62 +106,38 @@ public class ApplicationTest
     public void testGroovy() throws Exception {
         final Options options = new Options();
 
-        options.addOption(
-            OptionBuilder.withLongOpt("define").
-                withDescription("define a system property").
-                hasArg(true).
-                withArgName("name=value").
-                create('D'));
-        options.addOption(
-            OptionBuilder.hasArg(false)
-            .withDescription("usage information")
-            .withLongOpt("help")
-            .create('h'));
-        options.addOption(
-            OptionBuilder.hasArg(false)
-            .withDescription("debug mode will print out full stack traces")
-            .withLongOpt("debug")
-            .create('d'));
-        options.addOption(
-            OptionBuilder.hasArg(false)
-            .withDescription("display the Groovy and JVM versions")
-            .withLongOpt("version")
-            .create('v'));
-        options.addOption(
-            OptionBuilder.withArgName("charset")
-            .hasArg()
-            .withDescription("specify the encoding of the files")
-            .withLongOpt("encoding")
-            .create('c'));
-        options.addOption(
-            OptionBuilder.withArgName("script")
-            .hasArg()
-            .withDescription("specify a command line script")
-            .create('e'));
-        options.addOption(
-            OptionBuilder.withArgName("extension")
-            .hasOptionalArg()
-            .withDescription("modify files in place; create backup if extension is given (e.g. \'.bak\')")
-            .create('i'));
-        options.addOption(
-            OptionBuilder.hasArg(false)
-            .withDescription("process files line by line using implicit 'line' variable")
-            .create('n'));
-        options.addOption(
-            OptionBuilder.hasArg(false)
-            .withDescription("process files line by line and print result (see also -n)")
-            .create('p'));
-        options.addOption(
-            OptionBuilder.withArgName("port")
-            .hasOptionalArg()
-            .withDescription("listen on a port and process inbound lines")
-            .create('l'));
-        options.addOption(
-            OptionBuilder.withArgName("splitPattern")
-            .hasOptionalArg()
-            .withDescription("split lines using splitPattern (default '\\s') using implicit 'split' variable")
-            .withLongOpt("autosplit")
-            .create('a'));
+        options.addOption( Option.builder("D").longOpt("define").hasArg(true).argName("name=value")
+                          .desc("define a system property").build() );
+
+        options.addOption( Option.builder("h").longOpt("help").hasArg(false).desc("usage information").build() );
+
+        options.addOption( Option.builder("d").longOpt("debug").hasArg(false)
+                          .desc("debug mode will print out full stack traces").build() );
+
+        options.addOption( Option.builder("v").longOpt("version").hasArg(false)
+                          .desc("display the Groovy and JVM versions").build() );
+
+        options.addOption( Option.builder("c").longOpt("encoding").hasArg().argName("charset")
+                          .desc("specify the encoding of the files").build() );
+
+        options.addOption( Option.builder("e").hasArg().argName("script")
+                          .desc("specify a command line script").build() );
+
+        options.addOption( Option.builder("i").argName("extension").hasArg().optionalArg(true)
+                          .desc("modify files in place; create backup if extension is given (e.g. \'.bak\')").build() );
+
+        options.addOption( Option.builder("n").hasArg(false)
+                          .desc("process files line by line using implicit 'line' variable").build() );
+
+        options.addOption( Option.builder("p").hasArg(false)
+                          .desc("process files line by line and print result (see also -n)").build() );
+
+        options.addOption( Option.builder("l").argName("port").hasArg().optionalArg(true)
+                          .desc("listen on a port and process inbound lines").build() );
+
+        options.addOption( Option.builder("a").argName("splitPattern").hasArg().optionalArg(true)
+                          .desc("split lines using splitPattern (default '\\s') using implicit 'split' variable")
+                          .longOpt("autosplit").build() );
 
         final Parser parser = new PosixParser();
         final CommandLine line = parser.parse(options, new String[] { "-e", "println 'hello'" }, true);
@@ -280,30 +248,21 @@ public class ApplicationTest
         final Option newRun = new Option("n", "new", false, "Create NLT cache entries only for new items");
         final Option trackerRun = new Option("t", "tracker", false, "Create NLT cache entries only for tracker items");
 
-        final Option timeLimit = OptionBuilder.withLongOpt("limit").hasArg()
-                                        .withValueSeparator()
-                                        .withDescription("Set time limit for execution, in minutes")
-                                        .create("l");
+        final Option timeLimit = Option.builder("l").longOpt("limit").hasArg().valueSeparator()
+                                .desc("Set time limit for execution, in minutes").build();
 
-        final Option age = OptionBuilder.withLongOpt("age").hasArg()
-                                  .withValueSeparator()
-                                  .withDescription("Age (in days) of cache item before being recomputed")
-                                  .create("a");
+        final Option age = Option.builder("a").longOpt("age").hasArg().valueSeparator()
+                          .desc("Age (in days) of cache item before being recomputed").build();
 
-        final Option server = OptionBuilder.withLongOpt("server").hasArg()
-                                     .withValueSeparator()
-                                     .withDescription("The NLT server address")
-                                     .create("s");
 
-        final Option numResults = OptionBuilder.withLongOpt("results").hasArg()
-                                         .withValueSeparator()
-                                         .withDescription("Number of results per item")
-                                         .create("r");
+        final Option server = Option.builder("s").longOpt("server").hasArg().valueSeparator()
+                             .desc("The NLT server address").build();
 
-        final Option configFile = OptionBuilder.withLongOpt("file").hasArg()
-                                         .withValueSeparator()
-                                         .withDescription("Use the specified configuration file")
-                                         .create();
+        final Option numResults = Option.builder("r").longOpt("result").hasArg().valueSeparator()
+                                 .desc("Number of results per item").build();
+
+        final Option configFile = Option.builder().longOpt("file").hasArg().valueSeparator()
+                                 .desc("Use the specified configuration file").build();
 
         final Options options = new Options();
         options.addOption(help);

--- a/src/test/java/org/apache/commons/cli/CommandLineTest.java
+++ b/src/test/java/org/apache/commons/cli/CommandLineTest.java
@@ -34,8 +34,8 @@ public class CommandLineTest
         final String[] args = new String[] { "-Dparam1=value1", "-Dparam2=value2", "-Dparam3", "-Dparam4=value4", "-D", "--property", "foo=bar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withValueSeparator().hasOptionalArgs(2).create('D'));
-        options.addOption(OptionBuilder.withValueSeparator().hasArgs(2).withLongOpt("property").create());
+        options.addOption(Option.builder("D").valueSeparator().numberOfArgs(2).optionalArg(true).build());
+        options.addOption(Option.builder().valueSeparator().numberOfArgs(2).longOpt("property").build());
 
         final Parser parser = new GnuParser();
         final CommandLine cl = parser.parse(options, args);
@@ -57,8 +57,8 @@ public class CommandLineTest
         final String[] args = new String[] { "-Dparam1=value1", "-Dparam2=value2", "-Dparam3", "-Dparam4=value4", "-D", "--property", "foo=bar" };
 
         final Options options = new Options();
-        final Option option_D = OptionBuilder.withValueSeparator().hasOptionalArgs(2).create('D');
-        final Option option_property = OptionBuilder.withValueSeparator().hasArgs(2).withLongOpt("property").create();
+        final Option option_D = Option.builder("D").valueSeparator().numberOfArgs(2).optionalArg(true).build();
+        final Option option_property = Option.builder().valueSeparator().numberOfArgs(2).longOpt("property").build();
         options.addOption(option_D);
         options.addOption(option_property);
 
@@ -93,8 +93,8 @@ public class CommandLineTest
     @Test
     public void testGetParsedOptionValue() throws Exception {
         final Options options = new Options();
-        options.addOption(OptionBuilder.hasArg().withType(Number.class).create("i"));
-        options.addOption(OptionBuilder.hasArg().create("f"));
+        options.addOption(Option.builder("i").hasArg().type(Number.class).build());
+        options.addOption(Option.builder("f").hasArg().build());
 
         final CommandLineParser parser = new DefaultParser();
         final CommandLine cmd = parser.parse(options, new String[] { "-i", "123", "-f", "foo" });

--- a/src/test/java/org/apache/commons/cli/OptionGroupTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionGroupTest.java
@@ -248,8 +248,8 @@ public class OptionGroupTest
     public void testGetNames()
     {
         final OptionGroup group = new OptionGroup();
-        group.addOption(OptionBuilder.create('a'));
-        group.addOption(OptionBuilder.create('b'));
+        group.addOption(Option.builder("a").build());
+        group.addOption(Option.builder("b").build());
 
         assertNotNull("null names", group.getNames());
         assertEquals(2, group.getNames().size());

--- a/src/test/java/org/apache/commons/cli/OptionsTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionsTest.java
@@ -76,12 +76,12 @@ public class OptionsTest
     @Test
     public void testHelpOptions()
     {
-        final Option longOnly1 = OptionBuilder.withLongOpt("long-only1").create();
-        final Option longOnly2 = OptionBuilder.withLongOpt("long-only2").create();
-        final Option shortOnly1 = OptionBuilder.create("1");
-        final Option shortOnly2 = OptionBuilder.create("2");
-        final Option bothA = OptionBuilder.withLongOpt("bothA").create("a");
-        final Option bothB = OptionBuilder.withLongOpt("bothB").create("b");
+        final Option longOnly1 = Option.builder().longOpt("long-only1").build();
+        final Option longOnly2 = Option.builder().longOpt("long-only2").build();
+        final Option shortOnly1 = Option.builder("1").build();
+        final Option shortOnly2 = Option.builder("2").build();
+        final Option bothA = Option.builder("a").longOpt("bothA").build();
+        final Option bothB = Option.builder("b").longOpt("bothB").build();
 
         final Options options = new Options();
         options.addOption(longOnly1);
@@ -109,7 +109,7 @@ public class OptionsTest
     public void testMissingOptionException() throws ParseException
     {
         final Options options = new Options();
-        options.addOption(OptionBuilder.isRequired().create("f"));
+        options.addOption(Option.builder("f").required().build());
         try
         {
             new PosixParser().parse(options, new String[0]);
@@ -125,8 +125,8 @@ public class OptionsTest
     public void testMissingOptionsException() throws ParseException
     {
         final Options options = new Options();
-        options.addOption(OptionBuilder.isRequired().create("f"));
-        options.addOption(OptionBuilder.isRequired().create("x"));
+        options.addOption(Option.builder("f").required().build());
+        options.addOption(Option.builder("x").required().build());
         try
         {
             new PosixParser().parse(options, new String[0]);
@@ -157,12 +157,12 @@ public class OptionsTest
         final Options options = new Options();
 
         final OptionGroup group1 = new OptionGroup();
-        group1.addOption(OptionBuilder.create('a'));
-        group1.addOption(OptionBuilder.create('b'));
+        group1.addOption(Option.builder("a").build());
+        group1.addOption(Option.builder("b").build());
 
         final OptionGroup group2 = new OptionGroup();
-        group2.addOption(OptionBuilder.create('x'));
-        group2.addOption(OptionBuilder.create('y'));
+        group2.addOption(Option.builder("x").build());
+        group2.addOption(Option.builder("y").build());
 
         options.addOptionGroup(group1);
         options.addOptionGroup(group2);
@@ -175,8 +175,8 @@ public class OptionsTest
     public void testGetMatchingOpts()
     {
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("version").create());
-        options.addOption(OptionBuilder.withLongOpt("verbose").create());
+        options.addOption(Option.builder().longOpt("version").build());
+        options.addOption(Option.builder().longOpt("verbose").build());
 
         assertTrue(options.getMatchingOptions("foo").isEmpty());
         assertEquals(1, options.getMatchingOptions("version").size());

--- a/src/test/java/org/apache/commons/cli/ParserTestCase.java
+++ b/src/test/java/org/apache/commons/cli/ParserTestCase.java
@@ -173,8 +173,8 @@ public abstract class ParserTestCase
     public void testDoubleDash2() throws Exception
     {
         final Options options = new Options();
-        options.addOption(OptionBuilder.hasArg().create('n'));
-        options.addOption(OptionBuilder.create('m'));
+        options.addOption(Option.builder("n").hasArg().build());
+        options.addOption(Option.builder("m").build());
 
         try
         {
@@ -291,7 +291,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-f=bar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").hasArg().create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").hasArg().build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -304,7 +304,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-fbar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").hasArg().create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").hasArg().build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -317,7 +317,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "--foo=bar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").hasArg().create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").hasArg().build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -330,7 +330,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-foo=bar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").hasArg().create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").hasArg().build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -343,7 +343,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-foobar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").hasArg().create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").hasArg().build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -356,8 +356,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-b", "-foobar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").hasOptionalArg().create('f'));
-        options.addOption(OptionBuilder.withLongOpt("bar").hasOptionalArg().create('b'));
+        options.addOption(Option.builder("f").longOpt("foo").numberOfArgs(1).optionalArg(true).build());
+        options.addOption(Option.builder("b").longOpt("bar").numberOfArgs(1).optionalArg(true).build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -372,7 +372,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "--foobar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").hasArg().create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").hasArg().build());
 
         final CommandLine cl = parser.parse(options, args, true);
 
@@ -385,7 +385,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "--foo=bar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").build());
 
         try
         {
@@ -406,7 +406,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-foobar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").build());
 
         try
         {
@@ -427,7 +427,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-f=bar" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("foo").create('f'));
+        options.addOption(Option.builder("f").longOpt("foo").build());
 
         try
         {
@@ -448,7 +448,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-Jsource=1.5", "-J", "target", "1.5", "foo" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withValueSeparator().hasArgs(2).create('J'));
+        options.addOption(Option.builder("J").valueSeparator().numberOfArgs(2).build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -471,7 +471,7 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-Dparam1", "-Dparam2=value2", "-D"};
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withValueSeparator().hasOptionalArgs(2).create('D'));
+        options.addOption(Option.builder("D").valueSeparator().numberOfArgs(2).optionalArg(true).build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -491,8 +491,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "--ver" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("version").create());
-        options.addOption(OptionBuilder.withLongOpt("help").create());
+        options.addOption(Option.builder().longOpt("version").build());
+        options.addOption(Option.builder().longOpt("help").build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -505,8 +505,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-ver" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("version").create());
-        options.addOption(OptionBuilder.withLongOpt("help").create());
+        options.addOption(Option.builder().longOpt("version").build());
+        options.addOption(Option.builder().longOpt("help").build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -519,8 +519,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "--ver=1" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("verbose").hasOptionalArg().create());
-        options.addOption(OptionBuilder.withLongOpt("help").create());
+        options.addOption(Option.builder().longOpt("verbose").numberOfArgs(1).optionalArg(true).build());
+        options.addOption(Option.builder().longOpt("help").build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -534,8 +534,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-ver=1" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("verbose").hasOptionalArg().create());
-        options.addOption(OptionBuilder.withLongOpt("help").create());
+        options.addOption(Option.builder().longOpt("verbose").numberOfArgs(1).optionalArg(true).build());
+        options.addOption(Option.builder().longOpt("help").build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -549,8 +549,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "--ver" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("version").create());
-        options.addOption(OptionBuilder.withLongOpt("verbose").create());
+        options.addOption(Option.builder().longOpt("version").build());
+        options.addOption(Option.builder().longOpt("verbose").build());
 
         boolean caught = false;
 
@@ -575,8 +575,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-ver" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("version").create());
-        options.addOption(OptionBuilder.withLongOpt("verbose").create());
+        options.addOption(Option.builder().longOpt("version").build());
+        options.addOption(Option.builder().longOpt("verbose").build());
 
         boolean caught = false;
 
@@ -601,8 +601,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "--ver=1" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("version").create());
-        options.addOption(OptionBuilder.withLongOpt("verbose").hasOptionalArg().create());
+        options.addOption(Option.builder().longOpt("version").build());
+        options.addOption(Option.builder().longOpt("verbose").numberOfArgs(1).optionalArg(true).build());
 
         boolean caught = false;
 
@@ -627,8 +627,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-ver=1" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("version").create());
-        options.addOption(OptionBuilder.withLongOpt("verbose").hasOptionalArg().create());
+        options.addOption(Option.builder().longOpt("version").build());
+        options.addOption(Option.builder().longOpt("verbose").numberOfArgs(1).optionalArg(true).build());
 
         boolean caught = false;
 
@@ -653,8 +653,8 @@ public abstract class ParserTestCase
         final String[] args = new String[] { "-ver" };
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("version").create());
-        options.addOption(OptionBuilder.hasArg().create('v'));
+        options.addOption(Option.builder().longOpt("version").build());
+        options.addOption(Option.builder("v").hasArg().build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -669,7 +669,7 @@ public abstract class ParserTestCase
 
         final Options options = new Options();
         options.addOption("a", "enable-a", false, null);
-        options.addOption(OptionBuilder.withLongOpt("bfile").hasArg().isRequired().create('b'));
+        options.addOption(Option.builder("b").longOpt("bfile").hasArg().required().build());
 
         final CommandLine cl = parser.parse(options,args);
 
@@ -686,7 +686,7 @@ public abstract class ParserTestCase
 
         final Options options = new Options();
         options.addOption("a", "enable-a", false, null);
-        options.addOption(OptionBuilder.withLongOpt("bfile").hasArg().isRequired().create('b'));
+        options.addOption(Option.builder("b").longOpt("bfile").hasArg().required().build());
 
         final CommandLine cl = parser.parse(options,args);
 
@@ -703,7 +703,7 @@ public abstract class ParserTestCase
 
         final Options options = new Options();
         options.addOption("a", "enable-a", false, null);
-        options.addOption(OptionBuilder.withLongOpt("bfile").hasArg().isRequired().create('b'));
+        options.addOption(Option.builder("b").longOpt("bfile").hasArg().required().build());
 
         try
         {
@@ -728,8 +728,8 @@ public abstract class ParserTestCase
 
         final Options options = new Options();
         options.addOption("a", "enable-a", false, null);
-        options.addOption(OptionBuilder.withLongOpt("bfile").hasArg().isRequired().create('b'));
-        options.addOption(OptionBuilder.withLongOpt("cfile").hasArg().isRequired().create('c'));
+        options.addOption(Option.builder("b").longOpt("bfile").hasArg().required().build());
+        options.addOption(Option.builder("c").longOpt("cfile").hasArg().required().build());
 
         try
         {
@@ -752,13 +752,13 @@ public abstract class ParserTestCase
     public void testMissingRequiredGroup() throws Exception
     {
         final OptionGroup group = new OptionGroup();
-        group.addOption(OptionBuilder.create("a"));
-        group.addOption(OptionBuilder.create("b"));
+        group.addOption(Option.builder("a").build());
+        group.addOption(Option.builder("b").build());
         group.setRequired(true);
 
         final Options options = new Options();
         options.addOptionGroup(group);
-        options.addOption(OptionBuilder.isRequired().create("c"));
+        options.addOption(Option.builder("c").required().build());
 
         try
         {
@@ -780,8 +780,8 @@ public abstract class ParserTestCase
     public void testOptionGroup() throws Exception
     {
         final OptionGroup group = new OptionGroup();
-        group.addOption(OptionBuilder.create("a"));
-        group.addOption(OptionBuilder.create("b"));
+        group.addOption(Option.builder("a").build());
+        group.addOption(Option.builder("b").build());
 
         final Options options = new Options();
         options.addOptionGroup(group);
@@ -795,8 +795,8 @@ public abstract class ParserTestCase
     public void testOptionGroupLong() throws Exception
     {
         final OptionGroup group = new OptionGroup();
-        group.addOption(OptionBuilder.withLongOpt("foo").create());
-        group.addOption(OptionBuilder.withLongOpt("bar").create());
+        group.addOption(Option.builder().longOpt("foo").build());
+        group.addOption(Option.builder().longOpt("bar").build());
 
         final Options options = new Options();
         options.addOptionGroup(group);
@@ -811,7 +811,7 @@ public abstract class ParserTestCase
     public void testReuseOptionsTwice() throws Exception
     {
         final Options opts = new Options();
-        opts.addOption(OptionBuilder.isRequired().create('v'));
+        opts.addOption(Option.builder("v").required().build());
 
         // first parsing
         parser.parse(opts, new String[] { "-v" });
@@ -915,8 +915,8 @@ public abstract class ParserTestCase
         final String[] args = new String[]{"-e", "one", "two", "-f", "alpha"};
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.hasArgs().create("e"));
-        options.addOption(OptionBuilder.hasArgs().create("f"));
+        options.addOption(Option.builder("e").hasArgs().build());
+        options.addOption(Option.builder("f").hasArgs().build());
 
         final CommandLine cl = parser.parse(options, args);
 
@@ -941,7 +941,7 @@ public abstract class ParserTestCase
     public void testPropertyOptionSingularValue() throws Exception
     {
         final Options opts = new Options();
-        opts.addOption(OptionBuilder.hasOptionalArgs(2).withLongOpt("hide").create());
+        opts.addOption(Option.builder().numberOfArgs(2).optionalArg(true).longOpt("hide").build());
 
         final Properties properties = new Properties();
         properties.setProperty( "hide", "seek" );
@@ -958,7 +958,7 @@ public abstract class ParserTestCase
         final Options opts = new Options();
         opts.addOption("a", false, "toggle -a");
         opts.addOption("c", "c", false, "toggle -c");
-        opts.addOption(OptionBuilder.hasOptionalArg().create('e'));
+        opts.addOption(Option.builder("e").numberOfArgs(1).optionalArg(true).build());
 
         Properties properties = new Properties();
         properties.setProperty("a", "true");
@@ -1016,7 +1016,7 @@ public abstract class ParserTestCase
     public void testPropertyOptionMultipleValues() throws Exception
     {
         final Options opts = new Options();
-        opts.addOption(OptionBuilder.hasArgs().withValueSeparator(',').create('k'));
+        opts.addOption(Option.builder("k").hasArgs().valueSeparator(',').build());
 
         final Properties properties = new Properties();
         properties.setProperty( "k", "one,two" );
@@ -1032,8 +1032,8 @@ public abstract class ParserTestCase
     public void testPropertyOverrideValues() throws Exception
     {
         final Options opts = new Options();
-        opts.addOption(OptionBuilder.hasOptionalArgs(2).create('i'));
-        opts.addOption(OptionBuilder.hasOptionalArgs().create('j'));
+        opts.addOption(Option.builder("i").numberOfArgs(2).optionalArg(true).build());
+        opts.addOption(Option.builder("j").numberOfArgs(1).optionalArg(true).build());
 
         final String[] args = new String[] { "-j", "found", "-i", "ink" };
 
@@ -1052,7 +1052,7 @@ public abstract class ParserTestCase
     public void testPropertyOptionRequired() throws Exception
     {
         final Options opts = new Options();
-        opts.addOption(OptionBuilder.isRequired().create("f"));
+        opts.addOption(Option.builder("f").required().build());
 
         final Properties properties = new Properties();
         properties.setProperty("f", "true");

--- a/src/test/java/org/apache/commons/cli/ValueTest.java
+++ b/src/test/java/org/apache/commons/cli/ValueTest.java
@@ -39,12 +39,13 @@ public class ValueTest
         opts.addOption("c", "c", false, "toggle -c");
         opts.addOption("d", "d", true, "set -d");
 
-        opts.addOption(OptionBuilder.hasOptionalArg().create('e'));
-        opts.addOption(OptionBuilder.hasOptionalArg().withLongOpt("fish").create());
-        opts.addOption(OptionBuilder.hasOptionalArgs().withLongOpt("gravy").create());
-        opts.addOption(OptionBuilder.hasOptionalArgs(2).withLongOpt("hide").create());
-        opts.addOption(OptionBuilder.hasOptionalArgs(2).create('i'));
-        opts.addOption(OptionBuilder.hasOptionalArgs().create('j'));
+
+        opts.addOption(Option.builder("e").optionalArg(true).hasArg().build());
+        opts.addOption(Option.builder().longOpt("fish").optionalArg(true).hasArg().build());
+        opts.addOption(Option.builder().longOpt("gravy").optionalArg(true).hasArgs().build());
+        opts.addOption(Option.builder().longOpt("hide").optionalArg(true).numberOfArgs(2).build());
+        opts.addOption(Option.builder("i").optionalArg(true).numberOfArgs(2).build());
+        opts.addOption(Option.builder("j").optionalArg(true).hasArgs().build());
 
         final String[] args = new String[] { "-a",
             "-b", "foo",

--- a/src/test/java/org/apache/commons/cli/ValuesTest.java
+++ b/src/test/java/org/apache/commons/cli/ValuesTest.java
@@ -40,14 +40,14 @@ public class ValuesTest
         options.addOption("c", "c", false, "toggle -c");
         options.addOption("d", "d", true, "set -d");
 
-        options.addOption(OptionBuilder.withLongOpt("e").hasArgs().withDescription("set -e ").create('e'));
+        options.addOption(Option.builder("e").longOpt("e").hasArgs().desc("set -e").build());
         options.addOption("f", "f", false, "jk");
-        options.addOption(OptionBuilder.withLongOpt("g").hasArgs(2).withDescription("set -g").create('g'));
-        options.addOption(OptionBuilder.withLongOpt("h").hasArg().withDescription("set -h").create('h'));
-        options.addOption(OptionBuilder.withLongOpt("i").withDescription("set -i").create('i'));
-        options.addOption(OptionBuilder.withLongOpt("j").hasArgs().withDescription("set -j").withValueSeparator('=').create('j'));
-        options.addOption(OptionBuilder.withLongOpt("k").hasArgs().withDescription("set -k").withValueSeparator('=').create('k'));
-        options.addOption(OptionBuilder.withLongOpt("m").hasArgs().withDescription("set -m").withValueSeparator().create('m'));
+        options.addOption(Option.builder("g").longOpt("g").numberOfArgs(2).desc("set -g").build());
+        options.addOption(Option.builder("h").longOpt("h").hasArg().desc("set -h").build());
+        options.addOption(Option.builder("i").longOpt("i").desc("set -i").build());
+        options.addOption(Option.builder("j").longOpt("j").hasArgs().desc("set -j").valueSeparator('=').build());
+        options.addOption(Option.builder("k").longOpt("k").hasArgs().desc("set -k").valueSeparator('=').build());
+        options.addOption(Option.builder("m").longOpt("m").hasArgs().desc("set -m").valueSeparator().build());
 
         final String[] args = new String[] { "-a",
                                        "-b", "foo",

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI13Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI13Test.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
@@ -36,13 +35,9 @@ public class BugCLI13Test
     {
         final String debugOpt = "debug";
         @SuppressWarnings("static-access")
-        final
-        Option debug = OptionBuilder
-            .withArgName( debugOpt )
-            .withDescription( "turn on debugging" )
-            .withLongOpt( debugOpt )
-            .hasArg()
-            .create( 'd' );
+        final Option debug = Option.builder("d").longOpt(debugOpt).hasArg().argName(debugOpt)
+                            .desc("turn on debugging").build();
+
         final Options options = new Options();
         options.addOption( debug );
         final CommandLine commandLine = new PosixParser().parse( options, new String[]{"-d", "true"} );

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI148Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI148Test.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
 import org.junit.Before;
@@ -39,8 +39,8 @@ public class BugCLI148Test
     public void setUp() throws Exception
     {
         options = new Options();
-        options.addOption(OptionBuilder.hasArg().create('t'));
-        options.addOption(OptionBuilder.hasArg().create('s'));
+        options.addOption(Option.builder("t").hasArg().build());
+        options.addOption(Option.builder("s").hasArg().build());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/bug/BugsTest.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugsTest.java
@@ -33,7 +33,6 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -48,7 +47,7 @@ public class BugsTest
     public void test11457() throws Exception
     {
         final Options options = new Options();
-        options.addOption(OptionBuilder.withLongOpt("verbose").create());
+        options.addOption(Option.builder().longOpt("verbose").build());
         final String[] args = new String[]{"--verbose"};
 
         final CommandLineParser parser = new PosixParser();
@@ -61,8 +60,8 @@ public class BugsTest
     public void test11458() throws Exception
     {
         final Options options = new Options();
-        options.addOption( OptionBuilder.withValueSeparator( '=' ).hasArgs().create( 'D' ) );
-        options.addOption( OptionBuilder.withValueSeparator( ':' ).hasArgs().create( 'p' ) );
+        options.addOption( Option.builder("D").valueSeparator('=').hasArgs().build() );
+        options.addOption( Option.builder("p").valueSeparator(':').hasArgs().build() );
         final String[] args = new String[] { "-DJAVA_HOME=/opt/java" , "-pfile1:file2:file3" };
 
         final CommandLineParser parser = new PosixParser();
@@ -122,8 +121,8 @@ public class BugsTest
     {
         // Posix
         Options options = new Options();
-        options.addOption( OptionBuilder.hasOptionalArg().create( 'a' ) );
-        options.addOption( OptionBuilder.hasArg().create( 'b' ) );
+        options.addOption( Option.builder("a").hasArg().optionalArg(true).build() );
+        options.addOption( Option.builder("b").hasArg().build() );
         String[] args = new String[] { "-a", "-bvalue" };
 
         CommandLineParser parser = new PosixParser();
@@ -133,8 +132,8 @@ public class BugsTest
 
         // GNU
         options = new Options();
-        options.addOption( OptionBuilder.hasOptionalArg().create( 'a' ) );
-        options.addOption( OptionBuilder.hasArg().create( 'b' ) );
+        options.addOption( Option.builder("a").hasArg().optionalArg(true).build() );
+        options.addOption( Option.builder("b").hasArg().build() );
         args = new String[] { "-a", "-b", "value" };
 
         parser = new GnuParser();
@@ -204,14 +203,11 @@ public class BugsTest
     public void test13425() throws Exception
     {
         final Options options = new Options();
-        final Option oldpass = OptionBuilder.withLongOpt( "old-password" )
-            .withDescription( "Use this option to specify the old password" )
-            .hasArg()
-            .create( 'o' );
-        final Option newpass = OptionBuilder.withLongOpt( "new-password" )
-            .withDescription( "Use this option to specify the new password" )
-            .hasArg()
-            .create( 'n' );
+        final Option oldpass = Option.builder("o").longOpt("old-password").hasArg()
+                              .desc("Use this option to specify the old password").build();
+
+        final Option newpass = Option.builder("n").longOpt("new-password").hasArg()
+                              .desc("Use this option to specify the new password").build();
 
         final String[] args = {
             "-o",
@@ -235,7 +231,7 @@ public class BugsTest
     public void test13666() throws Exception
     {
         final Options options = new Options();
-        final Option dir = OptionBuilder.withDescription( "dir" ).hasArg().create( 'd' );
+        final Option dir = Option.builder("d").desc("dir").hasArg().build();
         options.addOption( dir );
 
         final PrintStream oldSystemOut = System.out;
@@ -312,7 +308,7 @@ public class BugsTest
     @Test
     public void test14786() throws Exception
     {
-        final Option o = OptionBuilder.isRequired().withDescription("test").create("test");
+        final Option o = Option.builder("test").required().desc("test").build();
         final Options opts = new Options();
         opts.addOption(o);
         opts.addOption(o);
@@ -348,7 +344,7 @@ public class BugsTest
     {
         final CommandLineParser parser = new PosixParser();
         final String[] args = new String[] { "-m", "\"Two Words\"" };
-        final Option m = OptionBuilder.hasArgs().create("m");
+        final Option m = Option.builder("m").hasArgs().build();
         final Options options = new Options();
         options.addOption( m );
         final CommandLine line = parser.parse( options, args );


### PR DESCRIPTION
OptionBuilder is marked deprecated now.
We could keep OptionBuilderTest for testing OptionBuilder, while other testcases should use Option.builder instead of deprecated OptionBuilder.