### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ script:
 
 after_success:
   - mvn clean test jacoco:report coveralls:report -Ptravis-jacoco --no-transfer-progress
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

If there are any inappropriate modifications in this PR, please give me feedback and I will change them.
