### PR TITLE
(doc) Fix Maven Central badge version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Apache Commons CLI
 [![Travis-CI Status](https://travis-ci.org/apache/commons-cli.svg)](https://travis-ci.org/apache/commons-cli)
 [![GitHub Actions Status](https://github.com/apache/commons-cli/workflows/Java%20CI/badge.svg)](https://github.com/apache/commons-cli/actions)
 [![Coverage Status](https://coveralls.io/repos/apache/commons-cli/badge.svg)](https://coveralls.io/r/apache/commons-cli)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/commons-cli/commons-cli/badge.svg)](https://maven-badges.herokuapp.com/maven-central/commons-cli/commons-cli/)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/commons-cli/commons-cli/badge.svg?gav=true)](https://maven-badges.herokuapp.com/maven-central/commons-cli/commons-cli/)
 [![Javadocs](https://javadoc.io/badge/commons-cli/commons-cli/1.5.0.svg)](https://javadoc.io/doc/commons-cli/commons-cli/1.5.0)
 
 Apache Commons CLI provides a simple API for presenting, processing and validating a Command Line Interface.


### PR DESCRIPTION
Fixes the [badge](https://github.com/softwaremill/maven-badges) version in the README.md to ignore the non-semver historical version.