### PR TITLE
Fix site links that are broken

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -70,7 +70,7 @@ usage: ls
         The Javadoc API documents are available online:
       </p>
       <ul>
-        <li><a href="/apidocs/index.html">Javadoc latest</a></li>
+        <li><a href="apidocs/index.html">Javadoc latest</a></li>
         <li><a href="https://javadoc.io/doc/commons-cli/commons-cli/latest/index.html">Javadoc archives</a></li>
       </ul>
       <p>
@@ -83,7 +83,7 @@ usage: ls
       <p>
         <a href="https://commons.apache.org/cli/download_cli.cgi">Download</a> the latest version. 
         <br/>
-        The <a href="/changes-report.html">release notes</a> are also available.
+        The <a href="changes-report.html">release notes</a> are also available.
       </p>
       <p>
         For previous releases, see the <a href="https://archive.apache.org/dist/commons/cli/">Apache Archive</a>.


### PR DESCRIPTION
Both of these [links](https://commons.apache.org/proper/commons-cli/index.html) cause 404 errors.

<img width="693" alt="Screen Shot 2023-01-03 at 2 52 51 PM" src="https://user-images.githubusercontent.com/1714978/210439755-619f2d29-fcbd-413c-bad0-3269ee6c0011.png">


<img width="475" alt="Screen Shot 2023-01-03 at 2 51 02 PM" src="https://user-images.githubusercontent.com/1714978/210439489-4f6d973b-d4bd-462f-92dc-a4781ca09af8.png">

<img width="491" alt="Screen Shot 2023-01-03 at 2 50 46 PM" src="https://user-images.githubusercontent.com/1714978/210439522-f43e0d19-dbae-4e04-9170-1575de3b164e.png">
