### PR TITLE
Git ignore all IntelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,9 @@ site-content
 /.classpath
 /.project
 /.settings/
-/commons-cli.iml
+
+### IntelliJ IDEA ###
+.idea/
+*.iws
+*.ipr
+*.iml


### PR DESCRIPTION
This is similar to how [commons-logging](https://github.com/apache/commons-logging/blob/master/.gitignore#L16-L20) does it.