### PR TITLE
CLI-313: Fixed StringIndexOutOfBoundsException for Java-like property token

### DIFF
--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -580,7 +580,7 @@ public class DefaultParser implements CommandLineParser {
      * Tests if the specified token is a Java-like property (-Dkey=value).
      */
     private boolean isJavaProperty(final String token) {
-        final String opt = token.substring(0, 1);
+        final String opt = token.isEmpty() ? null : token.substring(0, 1);
         final Option option = options.getOption(opt);
 
         return option != null && (option.getArgs() >= 2 || option.getArgs() == Option.UNLIMITED_VALUES);

--- a/src/test/java/org/apache/commons/cli/ParserTestCase.java
+++ b/src/test/java/org/apache/commons/cli/ParserTestCase.java
@@ -1020,5 +1020,12 @@ public abstract class ParserTestCase {
         assertEquals("Confirm arg of -b", "file", cl.getOptionValue("b"));
         assertTrue("Confirm NO of extra args", cl.getArgList().isEmpty());
     }
-
+    
+    @Test(expected = UnrecognizedOptionException.class)
+    public void testAmbiguousArgParsing() throws Exception {
+        final String[] args = {"-=-"};
+        final Options options = new Options();
+        
+        final CommandLine cl = parser.parse(options, args);
+    }
 }


### PR DESCRIPTION
Private method isJavaProperty isn't checking if token is empty. It should return null if the token is empty. Instead, it is giving StringIndexOutOfBoundsException. Fixed it in the code and added the unit test testAmbiguousArgParsing to capture the UnrecognizedOptionException