### PR TITLE
CLI-320: Awkward behavior of Option.builder() for multiple optional args

### DIFF
--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -201,7 +201,9 @@ public class Option implements Cloneable, Serializable {
          * @return this builder, to allow method chaining
          */
         public Builder optionalArg(final boolean optionalArg) {
-            this.argCount = optionalArg ? 1 : UNINITIALIZED;
+            if (optionalArg && this.argCount == UNINITIALIZED) {
+                this.argCount = 1;
+            }
             this.optionalArg = optionalArg;
             return this;
         }

--- a/src/test/java/org/apache/commons/cli/AbstractParserTestCase.java
+++ b/src/test/java/org/apache/commons/cli/AbstractParserTestCase.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -727,6 +728,54 @@ public abstract class AbstractParserTestCase {
         assertTrue(cmd.hasOption("i"));
         assertEquals("ink", cmd.getOptionValue("i"));
         assertFalse(cmd.hasOption("fake"));
+    }
+
+    @Test
+    public void testOptionalArgsOptionBuilder() throws Exception {
+        final Options opts = new Options();
+        opts.addOption(OptionBuilder.hasOptionalArgs(2).create('i'));
+        final Properties properties = new Properties();
+
+        CommandLine cmd = parse(parser, opts, new String[]{"-i"}, properties);
+        assertTrue(cmd.hasOption("i"));
+        assertNull(null, cmd.getOptionValues("i"));
+
+        cmd = parse(parser, opts, new String[]{"-i", "paper"}, properties);
+        assertTrue(cmd.hasOption("i"));
+        assertArrayEquals(new String[]{"paper"}, cmd.getOptionValues("i"));
+
+        cmd = parse(parser, opts, new String[]{"-i", "paper", "scissors"}, properties);
+        assertTrue(cmd.hasOption("i"));
+        assertArrayEquals(new String[]{"paper", "scissors"}, cmd.getOptionValues("i"));
+
+        cmd = parse(parser, opts, new String[]{"-i", "paper", "scissors", "rock"}, properties);
+        assertTrue(cmd.hasOption("i"));
+        assertArrayEquals(new String[]{"paper", "scissors"}, cmd.getOptionValues("i"));
+        assertArrayEquals(new String[]{"rock"}, cmd.getArgs());
+    }
+
+    @Test
+    public void testOptionalArgsOptionDotBuilder() throws Exception {
+        final Options opts = new Options();
+        opts.addOption(Option.builder("i").numberOfArgs(2).optionalArg(true).build());
+        final Properties properties = new Properties();
+
+        CommandLine cmd = parse(parser, opts, new String[]{"-i"}, properties);
+        assertTrue(cmd.hasOption("i"));
+        assertNull(null, cmd.getOptionValues("i"));
+
+        cmd = parse(parser, opts, new String[]{"-i", "paper"}, properties);
+        assertTrue(cmd.hasOption("i"));
+        assertArrayEquals(new String[]{"paper"}, cmd.getOptionValues("i"));
+
+        cmd = parse(parser, opts, new String[]{"-i", "paper", "scissors"}, properties);
+        assertTrue(cmd.hasOption("i"));
+        assertArrayEquals(new String[]{"paper", "scissors"}, cmd.getOptionValues("i"));
+
+        cmd = parse(parser, opts, new String[]{"-i", "paper", "scissors", "rock"}, properties);
+        assertTrue(cmd.hasOption("i"));
+        assertArrayEquals(new String[]{"paper", "scissors"}, cmd.getOptionValues("i"));
+        assertArrayEquals(new String[]{"rock"}, cmd.getArgs());
     }
 
     @Test


### PR DESCRIPTION
What it boils down to can be seen by looking at the `opts.addOption` lines in the supplied testCase (lines 736 and 760).

For 1.5.0, any of the following worked for creating the Option:
```
OptionBuilder.hasOptionalArgs(2).create('i')
Option.builder("i").optionalArg(true).numberOfArgs(2).build()
Option.builder("i").numberOfArgs(2).optionalArg(true).build()
```

For 1.6.0, the last variant now fails. The PR reinstates that variant.