### PR TITLE
Fixes for CLI-321

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,11 @@
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+    	<groupId>commons-beanutils</groupId>
+    	<artifactId>commons-beanutils</artifactId>
+    	<version>1.9.4</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/src/main/java/org/apache/commons/cli/CommandLine.java
+++ b/src/main/java/org/apache/commons/cli/CommandLine.java
@@ -351,8 +351,9 @@ public class CommandLine implements Serializable {
      * @throws ParseException if there are problems turning the option value into the desired type
      * @see PatternOptionBuilder
      * @since 1.5.0
+     * @param <T> The return type for the method.
      */
-    public Object getParsedOptionValue(final char opt) throws ParseException {
+    public <T> T getParsedOptionValue(final char opt) throws ParseException {
         return getParsedOptionValue(String.valueOf(opt));
     }
 
@@ -364,16 +365,10 @@ public class CommandLine implements Serializable {
      * @throws ParseException if there are problems turning the option value into the desired type
      * @see PatternOptionBuilder
      * @since 1.5.0
+     * @param <T> The return type for the method.
      */
-    public Object getParsedOptionValue(final Option option) throws ParseException {
-        if (option == null) {
-            return null;
-        }
-        final String res = getOptionValue(option);
-        if (res == null) {
-            return null;
-        }
-        return TypeHandler.createValue(res, option.getType());
+    public <T> T getParsedOptionValue(final Option option) throws ParseException {
+        return  getParsedOptionValue(option, null);
     }
 
     /**
@@ -384,9 +379,63 @@ public class CommandLine implements Serializable {
      * @throws ParseException if there are problems turning the option value into the desired type
      * @see PatternOptionBuilder
      * @since 1.2
+     * @param <T> The return type for the method.
      */
-    public Object getParsedOptionValue(final String opt) throws ParseException {
+    public <T> T getParsedOptionValue(final String opt) throws ParseException {
         return getParsedOptionValue(resolveOption(opt));
+    }
+    
+    /**
+     * Gets a version of this {@code Option} converted to a particular type.
+     *
+     * @param opt the name of the option.
+     * @param defaultValue the default value to return if opt is not set.
+     * @return the value parsed into a particular object.
+     * @throws ParseException if there are problems turning the option value into the desired type
+     * @see PatternOptionBuilder
+     * @since 1.7
+     * @param <T> The return type for the method.
+     */
+    public <T> T getParsedOptionValue(final char opt, T defaultValue) throws ParseException {
+        return getParsedOptionValue(String.valueOf(opt), defaultValue);
+    }
+
+    /**
+     * Gets a version of this {@code Option} converted to a particular type.
+     *
+     * @param option the name of the option.
+     * @param defaultValue the default value to return if opt is not set.
+     * @return the value parsed into a particular object.
+     * @throws ParseException if there are problems turning the option value into the desired type
+     * @see PatternOptionBuilder
+     * @since 1.7
+     * @param <T> The return type for the method.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getParsedOptionValue(final Option option, T defaultValue) throws ParseException {
+        if (option == null) {
+            return null;
+        }
+        final String res = getOptionValue(option);
+        if (res == null) {
+            return defaultValue;
+        }
+        return (T) TypeHandler.createValue(res, (Class<?>) option.getType());
+    }
+
+    /**
+     * Gets a version of this {@code Option} converted to a particular type.
+     *
+     * @param opt the name of the option.
+     * @param defaultValue the default value to return if opt is not set.
+     * @return the value parsed into a particular object.
+     * @throws ParseException if there are problems turning the option value into the desired type
+     * @see PatternOptionBuilder
+     * @since 1.7
+     * @param <T> The return type for the method.
+     */
+    public <T> T getParsedOptionValue(final String opt, T defaultValue) throws ParseException {
+        return getParsedOptionValue(resolveOption(opt), defaultValue);
     }
 
     /**

--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -20,11 +20,10 @@ package org.apache.commons.cli;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.commons.beanutils.ConversionException;
-import org.apache.commons.beanutils.ConvertUtilsBean;
+import org.apache.commons.beanutils.ConvertUtilsBean2;
 import org.apache.commons.beanutils.Converter;
 import org.apache.commons.beanutils.converters.ConverterFacade;
 import org.apache.commons.beanutils.converters.DateConverter;
@@ -37,10 +36,16 @@ import org.apache.commons.cli.converters.SimpleConverter;
  */
 public class TypeHandler {
 
-    private static ConvertUtilsBean convertUtils;
+    /**
+     * The conversion utilities from BeanUtils.
+     */
+    private static ConvertUtilsBean2 convertUtils;
 
+    /**
+     * Setup the convertUtils object
+     */
     static {
-        convertUtils = new ConvertUtilsBean();
+        convertUtils = new ConvertUtilsBean2();
         convertUtils.register(true, true, 0);
         /*
          * this can not be a ternary because the unboxing operations will result in it
@@ -59,7 +64,7 @@ public class TypeHandler {
         };
         convertUtils.register(new SimpleConverter<>(fn, Number.class), Number.class);
 
-        Func<Object> fo = (str) -> {
+        Func<Object> fo = str -> {
                 final Class<?> cl;
 
                 try {
@@ -238,7 +243,7 @@ public class TypeHandler {
      *                            value of {@code str}.
      * @throws     ParseException if the value creation for the given object type
      *                            failed
-     * @deprecated                use createValue(str, Class<?>);
+     * @deprecated                use {@link #createValue(String, Class)};
      */
     @Deprecated // (since="1.7")
     public static Object createValue(final String str, final Object obj) throws ParseException {

--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -20,6 +20,7 @@ package org.apache.commons.cli;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.commons.beanutils.ConversionException;
@@ -81,8 +82,20 @@ public class TypeHandler {
 
         // fixup date parsing
         DateConverter dc = new DateConverter();
-        dc.setUseLocaleFormat(true);
+        // should match "Thu Jun 06 17:48:57 EDT 2002"
+        dc.setPattern("EEE MMM dd HH:mm:ss zzz yyyy");
         convertUtils.register(new ConverterFacade(dc), Date.class);
+    }
+    
+    /**
+     * Registers a Converter for a class so that the class can be returned as the value of the command line option.
+     * Note: the converter will override any existing converter for the class.
+     *
+     * @param converter The converter to associate with the class.
+     * @param clazz the class that the converter handles.
+     */
+    public static void register(Converter converter, Class<?> clazz) {
+        convertUtils.register(converter, clazz);
     }
 
     /**

--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -19,63 +19,120 @@ package org.apache.commons.cli;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Date;
 
+import org.apache.commons.beanutils.ConversionException;
+import org.apache.commons.beanutils.ConvertUtilsBean;
+import org.apache.commons.beanutils.Converter;
+import org.apache.commons.beanutils.converters.ConverterFacade;
+import org.apache.commons.beanutils.converters.DateConverter;
+import org.apache.commons.cli.converters.Func;
+import org.apache.commons.cli.converters.SimpleConverter;
+
 /**
- * This is a temporary implementation. TypeHandler will handle the pluggableness of OptionTypes and it will direct all
- * of these types of conversion functionalities to ConvertUtils component in Commons already. BeanUtils I think.
+ * TypeHandler will handles the configuration of the Option type processing using
+ * the Commons BeanUtils ConvertUtilsBean class.
  */
 public class TypeHandler {
-    /**
-     * Returns the class whose name is {@code className}.
-     *
-     * @param className the class name
-     * @return The class if it is found
-     * @throws ParseException if the class could not be found
-     */
-    public static Class<?> createClass(final String className) throws ParseException {
-        try {
-            return Class.forName(className);
-        } catch (final ClassNotFoundException e) {
-            throw new ParseException("Unable to find the class: " + className);
-        }
+
+    private static ConvertUtilsBean convertUtils;
+
+    static {
+        convertUtils = new ConvertUtilsBean();
+        convertUtils.register(true, true, 0);
+        /*
+         * this can not be a ternary because the unboxing operations will result in it
+         * always being a Double.
+         * https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.25-300-A
+         */
+        Func<Number> fn = new Func<Number>() {
+
+            @Override
+            public Number apply(String str) throws ConversionException {
+                if (str.indexOf('.') == -1) {
+                    return Long.valueOf(str);
+                }
+                return Double.valueOf(str);
+            }
+        };
+        convertUtils.register(new SimpleConverter<>(fn, Number.class), Number.class);
+
+        Func<Object> fo = (str) -> {
+                final Class<?> cl;
+
+                try {
+                    cl = Class.forName(str);
+                } catch (final ClassNotFoundException cnfe) {
+                    throw new ConversionException("Unable to find the class: " + str);
+                }
+
+                try {
+                    return cl.getConstructor().newInstance();
+                } catch (final Exception e) {
+                    throw new ConversionException(e.getClass().getName() + "; Unable to create an instance of: " + str);
+                }
+            };
+        convertUtils.register(new SimpleConverter<>(fo, Object.class), Object.class);
+
+        convertUtils.register(
+                new SimpleConverter<>(str -> new FileInputStream(str), FileInputStream.class),
+                FileInputStream.class);
+
+        // fixup date parsing
+        DateConverter dc = new DateConverter();
+        dc.setUseLocaleFormat(true);
+        convertUtils.register(new ConverterFacade(dc), Date.class);
     }
 
     /**
-     * Returns the date represented by {@code str}.
-     * <p>
-     * This method is not yet implemented and always throws an {@link UnsupportedOperationException}.
+     * Returns the class whose name is {@code className}.
      *
-     * @param str the date string
-     * @return The date if {@code str} is a valid date string, otherwise return null.
-     * @throws UnsupportedOperationException always
+     * @param      className      the class name
+     * @return                    The class if it is found
+     * @throws     ParseException if the class could not be found
+     * @deprecated                use createValue(className,Class.class)
      */
+    @Deprecated // (since="1.7")
+    public static Class<?> createClass(final String className) throws ParseException {
+        return createValue(className, Class.class);
+    }
+
+    /**
+     * Returns the date represented by {@code str}. <p> This method is not yet
+     * implemented and always throws an {@link UnsupportedOperationException}.
+     *
+     * @param      str                           the date string
+     * @return                                   The date if {@code str} is a valid
+     *                                           date string, otherwise return null.
+     * @throws     UnsupportedOperationException always
+     * @deprecated                               use createValue(str, Date.class);
+     */
+    @Deprecated // (since="1.7")
     public static Date createDate(final String str) {
-        throw new UnsupportedOperationException("Not yet implemented");
+        return createValueNoException(str, Date.class);
     }
 
     /**
      * Returns the File represented by {@code str}.
      *
-     * @param str the File location
-     * @return The file represented by {@code str}.
+     * @param      str the File location
+     * @return         The file represented by {@code str}.
+     * @deprecated     use createValue(str, File.class);
      */
+    @Deprecated // (since="1.7")
     public static File createFile(final String str) {
-        return new File(str);
+        return createValueNoException(str, File.class);
     }
 
     /**
-     * Returns the File[] represented by {@code str}.
-     * <p>
-     * This method is not yet implemented and always throws an {@link UnsupportedOperationException}.
+     * Returns the File[] represented by {@code str}. <p> This method is not yet
+     * implemented and always throws an {@link UnsupportedOperationException}.
      *
-     * @param str the paths to the files
-     * @return The File[] represented by {@code str}.
-     * @throws UnsupportedOperationException always
+     * @param  str the paths to the files
+     * @return     The File[] represented by {@code str}.
      */
+    @Deprecated // (since="1.7")
     public static File[] createFiles(final String str) {
         // to implement/port:
         // return FileW.findFiles(str);
@@ -83,110 +140,94 @@ public class TypeHandler {
     }
 
     /**
-     * Create a number from a String. If a '.' is present, it creates a Double, otherwise a Long.
+     * Create a number from a String. If a '.' is present, it creates a Double,
+     * otherwise a Long.
      *
-     * @param str the value
-     * @return the number represented by {@code str}
-     * @throws ParseException if {@code str} is not a number
+     * @param      str            the value
+     * @return                    the number represented by {@code str}
+     * @throws     ParseException if {@code str} is not a number
+     * @deprecated                use createValue(str, Number.class);
      */
+    @Deprecated // (since="1.7")
     public static Number createNumber(final String str) throws ParseException {
-        try {
-            if (str.indexOf('.') != -1) {
-                return Double.valueOf(str);
-            }
-            return Long.valueOf(str);
-        } catch (final NumberFormatException e) {
-            throw new ParseException(e.getMessage());
-        }
+        return createValue(str, Number.class);
     }
 
     /**
      * Create an Object from the class name and empty constructor.
      *
-     * @param className the argument value
-     * @return the initialized object
-     * @throws ParseException if the class could not be found or the object could not be created
+     * @param      className      the argument value
+     * @return                    the initialized object
+     * @throws     ParseException if the class could not be found or the object
+     *                            could not be created
+     * @deprecated                use createValue(str, Object.class);
      */
+    @Deprecated // (since="1.7")
     public static Object createObject(final String className) throws ParseException {
-        final Class<?> cl;
-
-        try {
-            cl = Class.forName(className);
-        } catch (final ClassNotFoundException cnfe) {
-            throw new ParseException("Unable to find the class: " + className);
-        }
-
-        try {
-            return cl.getConstructor().newInstance();
-        } catch (final Exception e) {
-            throw new ParseException(e.getClass().getName() + "; Unable to create an instance of: " + className);
-        }
+        return createValue(className, Object.class);
     }
 
     /**
      * Returns the URL represented by {@code str}.
      *
-     * @param str the URL string
-     * @return The URL in {@code str} is well-formed
-     * @throws ParseException if the URL in {@code str} is not well-formed
+     * @param      str            the URL string
+     * @return                    The URL in {@code str} is well-formed
+     * @throws     ParseException if the URL in {@code str} is not well-formed
+     * @deprecated                use createValue(str, URL.class);
      */
+    @Deprecated // (since="1.7")
     public static URL createURL(final String str) throws ParseException {
+        return createValue(str, URL.class);
+    }
+
+    private static <T> T createValueNoException(final String str, Class<T> clazz) {
         try {
-            return new URL(str);
-        } catch (final MalformedURLException e) {
-            throw new ParseException("Unable to parse the URL: " + str);
+            return createValue(str, clazz);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
         }
     }
 
     /**
-     * Returns the {@code Object} of type {@code clazz} with the value of {@code str}.
+     * Returns the {@code Object} of type {@code clazz} with the value of
+     * {@code str}.
      *
-     * @param str the command line value
-     * @param clazz the class representing the type of argument
-     * @param <T> type of argument
-     * @return The instance of {@code clazz} initialized with the value of {@code str}.
+     * @param  str            the command line value
+     * @param  clazz          the class representing the type of argument
+     * @param  <T>            type of argument
+     * @return                The instance of {@code clazz} initialized with the
+     *                        value of {@code str}.
      * @throws ParseException if the value creation for the given class failed
      */
     @SuppressWarnings("unchecked") // returned value will have type T because it is fixed by clazz
-    public static <T> T createValue(final String str, final Class<T> clazz) throws ParseException {
-        if (PatternOptionBuilder.STRING_VALUE == clazz) {
-            return (T) str;
-        }
-        if (PatternOptionBuilder.OBJECT_VALUE == clazz) {
-            return (T) createObject(str);
-        }
-        if (PatternOptionBuilder.NUMBER_VALUE == clazz) {
-            return (T) createNumber(str);
-        }
-        if (PatternOptionBuilder.DATE_VALUE == clazz) {
-            return (T) createDate(str);
-        }
-        if (PatternOptionBuilder.CLASS_VALUE == clazz) {
-            return (T) createClass(str);
-        }
-        if (PatternOptionBuilder.FILE_VALUE == clazz) {
-            return (T) createFile(str);
-        }
-        if (PatternOptionBuilder.EXISTING_FILE_VALUE == clazz) {
-            return (T) openFile(str);
-        }
+    public static <T> T createValue(final String str, Class<T> clazz) throws ParseException {
+        //  BeanUtils convertUtils handles File[] but looks for the string to parse into file names.
         if (PatternOptionBuilder.FILES_VALUE == clazz) {
             return (T) createFiles(str);
         }
-        if (PatternOptionBuilder.URL_VALUE == clazz) {
-            return (T) createURL(str);
+        Converter converter = convertUtils.lookup(String.class, clazz);
+        if (converter == null) {
+            throw new ParseException(String.format("No registered converter for %s found", clazz));
         }
-        throw new ParseException("Unable to handle the class: " + clazz);
+        try {
+            return converter.convert(clazz, str);
+        } catch (ConversionException e) {
+            throw new ParseException(e);
+        }
     }
 
     /**
      * Returns the {@code Object} of type {@code obj} with the value of {@code str}.
      *
-     * @param str the command line value
-     * @param obj the type of argument
-     * @return The instance of {@code obj} initialized with the value of {@code str}.
-     * @throws ParseException if the value creation for the given object type failed
+     * @param      str            the command line value
+     * @param      obj            the type of argument
+     * @return                    The instance of {@code obj} initialized with the
+     *                            value of {@code str}.
+     * @throws     ParseException if the value creation for the given object type
+     *                            failed
+     * @deprecated                use createValue(str, Class<?>);
      */
+    @Deprecated // (since="1.7")
     public static Object createValue(final String str, final Object obj) throws ParseException {
         return createValue(str, (Class<?>) obj);
     }
@@ -194,15 +235,13 @@ public class TypeHandler {
     /**
      * Returns the opened FileInputStream represented by {@code str}.
      *
-     * @param str the file location
-     * @return The file input stream represented by {@code str}.
-     * @throws ParseException if the file is not exist or not readable
+     * @param      str            the file location
+     * @return                    The file input stream represented by {@code str}.
+     * @throws     ParseException if the file is not exist or not readable
+     * @deprecated                use createValue(str, URL.class);
      */
+    @Deprecated // (since="1.7")
     public static FileInputStream openFile(final String str) throws ParseException {
-        try {
-            return new FileInputStream(str);
-        } catch (final FileNotFoundException e) {
-            throw new ParseException("Unable to find file: " + str);
-        }
+        return createValue(str, FileInputStream.class);
     }
 }

--- a/src/main/java/org/apache/commons/cli/converters/Func.java
+++ b/src/main/java/org/apache/commons/cli/converters/Func.java
@@ -14,28 +14,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-
-package org.apache.commons.cli;
+package org.apache.commons.cli.converters;
 
 /**
- * Base for Exceptions thrown during parsing of a command-line.
+ * The definition of the functional interface to call when doing a conversion.
+ * Like Function<String,T> but can throw an Exception.
+ *
+ * @param <T> The return type for the function.
  */
-public class ParseException extends Exception {
-    /**
-     * This exception {@code serialVersionUID}.
-     */
-    private static final long serialVersionUID = 9112808380089253192L;
-
-    /**
-     * Constructs a new {@code ParseException} with the specified detail message.
-     *
-     * @param message the detail message
-     */
-    public ParseException(final String message) {
-        super(message);
-    }
-    
-    public ParseException(final Exception e) {
-        super(e);
-    }
+@FunctionalInterface
+public interface Func<T> {
+    T apply(String str) throws Exception;
 }

--- a/src/main/java/org/apache/commons/cli/converters/Func.java
+++ b/src/main/java/org/apache/commons/cli/converters/Func.java
@@ -18,11 +18,17 @@ package org.apache.commons.cli.converters;
 
 /**
  * The definition of the functional interface to call when doing a conversion.
- * Like Function<String,T> but can throw an Exception.
+ * Like {@code Function<String,T>} but can throw an Exception.
  *
  * @param <T> The return type for the function.
  */
 @FunctionalInterface
 public interface Func<T> {
+    /**
+     * Applies the conversion function to the String argument.
+     * @param str the String to convert
+     * @return the Object from the conversion.
+     * @throws Exception on error.
+     */
     T apply(String str) throws Exception;
 }

--- a/src/main/java/org/apache/commons/cli/converters/SimpleConverter.java
+++ b/src/main/java/org/apache/commons/cli/converters/SimpleConverter.java
@@ -1,0 +1,51 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package org.apache.commons.cli.converters;
+
+import org.apache.commons.beanutils.converters.AbstractConverter;
+
+/**
+ * A simple converter that takes a Func and the datatype to create a Converter
+ * for the BeanUtils.
+ *
+ * @param <T> The type of object the converter will return.
+ */
+public class SimpleConverter<T> extends AbstractConverter {
+
+    private final Func<? extends T> func;
+    private final Class<T> type;
+
+    public SimpleConverter(Func<? extends T> func, Class<T> type) {
+        this.func = func;
+        this.type = type;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected <T2> T2 convertToType(Class<T2> type, Object value) throws Throwable {
+        if (this.type.equals(type)) {
+            return (T2) func.apply(value.toString());
+        }
+
+        throw conversionException(type, value);
+    }
+
+    @Override
+    protected Class<?> getDefaultType() {
+        return type;
+    }
+}

--- a/src/main/java/org/apache/commons/cli/converters/SimpleConverter.java
+++ b/src/main/java/org/apache/commons/cli/converters/SimpleConverter.java
@@ -25,10 +25,19 @@ import org.apache.commons.beanutils.converters.AbstractConverter;
  * @param <T> The type of object the converter will return.
  */
 public class SimpleConverter<T> extends AbstractConverter {
-
+    /**
+     * The Func to convert string values.
+     */
     private final Func<? extends T> func;
+    /**
+     * The class type of the object that is returned.
+     */
     private final Class<T> type;
 
+    /**
+     * @param func the Func instance to use to convert values.
+     * @param type the Type that this Converter returns.
+     */
     public SimpleConverter(Func<? extends T> func, Class<T> type) {
         this.func = func;
         this.type = type;

--- a/src/main/java/org/apache/commons/cli/converters/package-info.java
+++ b/src/main/java/org/apache/commons/cli/converters/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Apache Commons CLI converters to convert from String to Object of various types.
+ */
+package org.apache.commons.cli.converters;

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -153,7 +153,6 @@ public class PatternOptionBuilderTest {
             // expected
         }
 
-        // DATES NOT SUPPORTED YET
         assertEquals("date flag z", new Date(1023400137000L), line.getOptionObject('z'));
 
     }

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -154,12 +154,8 @@ public class PatternOptionBuilderTest {
         }
 
         // DATES NOT SUPPORTED YET
-        try {
-            assertEquals("date flag z", new Date(1023400137276L), line.getOptionObject('z'));
-            fail("Date is not supported yet, should have failed");
-        } catch (final UnsupportedOperationException uoe) {
-            // expected
-        }
+        assertEquals("date flag z", new Date(1023400137000L), line.getOptionObject('z'));
+
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
+import java.text.DateFormat;
+import java.util.Date;
 
 import org.junit.Test;
 
@@ -51,11 +53,22 @@ public class TypeHandlerTest {
     }
 
     @Test
-    public void testCreateValueDate() {
-        assertThrows(UnsupportedOperationException.class, () ->
+    public void testBadValueDate() {
+        assertThrows(ParseException.class, () ->
                 TypeHandler.createValue("what ever", PatternOptionBuilder.DATE_VALUE));
     }
 
+    @Test
+    public void testCreateValueDate() throws Exception {
+        Date d = new Date();
+        DateFormat fmt = DateFormat.getDateInstance(DateFormat.SHORT);
+        String s = fmt.format(d);
+        d = fmt.parse(s);
+        Date d2 = TypeHandler.createValue(s, PatternOptionBuilder.DATE_VALUE);
+        assertEquals( d, d2 );
+    }
+
+    
     @Test
     public void testCreateValueExistingFile() throws Exception {
         try (FileInputStream result = TypeHandler.createValue("src/test/resources/org/apache/commons/cli/existing-readable.file",

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
-import java.text.DateFormat;
 import java.util.Date;
 
 import org.junit.Test;
@@ -62,7 +61,7 @@ public class TypeHandlerTest {
     public void testCreateValueDate() throws Exception {
         Date d = new Date(1023400137000L);
         Date d2 = TypeHandler.createValue("Thu Jun 06 17:48:57 EDT 2002", PatternOptionBuilder.DATE_VALUE);
-        assertEquals( d, d2 );
+        assertEquals(d, d2);
     }
 
     

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -60,11 +60,8 @@ public class TypeHandlerTest {
 
     @Test
     public void testCreateValueDate() throws Exception {
-        Date d = new Date();
-        DateFormat fmt = DateFormat.getDateInstance(DateFormat.SHORT);
-        String s = fmt.format(d);
-        d = fmt.parse(s);
-        Date d2 = TypeHandler.createValue(s, PatternOptionBuilder.DATE_VALUE);
+        Date d = new Date(1023400137000L);
+        Date d2 = TypeHandler.createValue("Thu Jun 06 17:48:57 EDT 2002", PatternOptionBuilder.DATE_VALUE);
         assertEquals( d, d2 );
     }
 


### PR DESCRIPTION
Adds BeanUtils dependency to POM and implements TypeHandler using the BeanUtils classes.

Handles all methods that were in the original TypeHandler as well as other default classes provided by BeanUtils. Test updated to show proper parsing of types that previously were not implemented.

Includes new cli.converters package that may be better handled by BeanUtils as it moves forward to support FunctionalInterfaces.