### PR TITLE
Update the tests to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,8 +193,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/commons/cli/AbstractParserTestCase.java
+++ b/src/test/java/org/apache/commons/cli/AbstractParserTestCase.java
@@ -17,21 +17,21 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test case testing common parser features.
@@ -52,7 +52,7 @@ public abstract class AbstractParserTestCase {
         throw new UnsupportedOperationException("Default options not supported by this parser");
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         //@formatter:off
         options = new Options()
@@ -113,12 +113,12 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, args);
         } catch (final AmbiguousOptionException e) {
             caught = true;
-            assertEquals("Partial option", "--ver", e.getOption());
-            assertNotNull("Matching options null", e.getMatchingOptions());
-            assertEquals("Matching options size", 2, e.getMatchingOptions().size());
+            assertEquals("--ver", e.getOption(), "Partial option");
+            assertNotNull(e.getMatchingOptions(), "Matching options null");
+            assertEquals(2, e.getMatchingOptions().size(), "Matching options size");
         }
 
-        assertTrue("Confirm MissingArgumentException caught", caught);
+        assertTrue(caught, "Confirm MissingArgumentException caught");
     }
 
     @Test
@@ -135,12 +135,12 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, args);
         } catch (final AmbiguousOptionException e) {
             caught = true;
-            assertEquals("Partial option", "-ver", e.getOption());
-            assertNotNull("Matching options null", e.getMatchingOptions());
-            assertEquals("Matching options size", 2, e.getMatchingOptions().size());
+            assertEquals("-ver", e.getOption(), "Partial option");
+            assertNotNull(e.getMatchingOptions(), "Matching options null");
+            assertEquals(2, e.getMatchingOptions().size(), "Matching options size");
         }
 
-        assertTrue("Confirm MissingArgumentException caught", caught);
+        assertTrue(caught, "Confirm MissingArgumentException caught");
     }
 
     @Test
@@ -157,12 +157,12 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, args);
         } catch (final AmbiguousOptionException e) {
             caught = true;
-            assertEquals("Partial option", "--ver", e.getOption());
-            assertNotNull("Matching options null", e.getMatchingOptions());
-            assertEquals("Matching options size", 2, e.getMatchingOptions().size());
+            assertEquals("--ver", e.getOption(), "Partial option");
+            assertNotNull(e.getMatchingOptions(), "Matching options null");
+            assertEquals(2, e.getMatchingOptions().size(), "Matching options size");
         }
 
-        assertTrue("Confirm MissingArgumentException caught", caught);
+        assertTrue(caught, "Confirm MissingArgumentException caught");
     }
 
     @Test
@@ -179,12 +179,12 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, args);
         } catch (final AmbiguousOptionException e) {
             caught = true;
-            assertEquals("Partial option", "-ver", e.getOption());
-            assertNotNull("Matching options null", e.getMatchingOptions());
-            assertEquals("Matching options size", 2, e.getMatchingOptions().size());
+            assertEquals("-ver", e.getOption(), "Partial option");
+            assertNotNull(e.getMatchingOptions(), "Matching options null");
+            assertEquals(2, e.getMatchingOptions().size(), "Matching options size");
         }
 
-        assertTrue("Confirm MissingArgumentException caught", caught);
+        assertTrue(caught, "Confirm MissingArgumentException caught");
     }
 
     @Test
@@ -201,11 +201,11 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -a is set", cl.hasOption("a"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertTrue("Confirm -c is set", cl.hasOption("c"));
-        assertEquals("Confirm arg of -b", "toast", cl.getOptionValue("b"));
-        assertEquals("Confirm size of extra args", 2, cl.getArgList().size());
+        assertTrue(cl.hasOption("a"), "Confirm -a is set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertTrue(cl.hasOption("c"), "Confirm -c is set");
+        assertEquals("toast", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertEquals(2, cl.getArgList().size(), "Confirm size of extra args");
     }
 
     @Test
@@ -214,9 +214,9 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -c is set", cl.hasOption("c"));
-        assertFalse("Confirm -b is not set", cl.hasOption("b"));
-        assertEquals("Confirm 2 extra args: " + cl.getArgList().size(), 2, cl.getArgList().size());
+        assertTrue(cl.hasOption("c"), "Confirm -c is set");
+        assertFalse(cl.hasOption("b"), "Confirm -b is not set");
+        assertEquals(2, cl.getArgList().size(), "Confirm 2 extra args: " + cl.getArgList().size());
     }
 
     @Test
@@ -229,7 +229,7 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, new String[] {"-n", "--", "-m"});
             fail("MissingArgumentException not thrown for option -n");
         } catch (final MissingArgumentException e) {
-            assertNotNull("option null", e.getOption());
+            assertNotNull(e.getOption(), "option null");
             assertEquals("n", e.getOption().getOpt());
         }
     }
@@ -240,7 +240,7 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm --bfile \"arg\" strips quotes",  "quoted string", cl.getOptionValue("b"));
+        assertEquals("quoted string", cl.getOptionValue("b"), "Confirm --bfile \"arg\" strips quotes");
     }
 
     @Test
@@ -249,7 +249,7 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm --bfile=\"arg\" strips quotes",  "quoted string", cl.getOptionValue("b"));
+        assertEquals("quoted string", cl.getOptionValue("b"), "Confirm --bfile=\"arg\" strips quotes");
     }
 
     @Test
@@ -344,10 +344,10 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, args);
         } catch (final MissingArgumentException e) {
             caught = true;
-            assertEquals("option missing an argument", "b", e.getOption().getOpt());
+            assertEquals("b", e.getOption().getOpt(), "option missing an argument");
         }
 
-        assertTrue("Confirm MissingArgumentException caught", caught);
+        assertTrue(caught, "Confirm MissingArgumentException caught");
     }
 
     @Test
@@ -360,10 +360,10 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, args);
         } catch (final MissingArgumentException e) {
             caught = true;
-            assertEquals("option missing an argument", "b", e.getOption().getOpt());
+            assertEquals("b", e.getOption().getOpt(), "option missing an argument");
         }
 
-        assertTrue("Confirm MissingArgumentException caught", caught);
+        assertTrue(caught, "Confirm MissingArgumentException caught");
     }
 
     @Test
@@ -400,7 +400,7 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, args);
             fail("exception should have been thrown");
         } catch (final MissingOptionException e) {
-            assertEquals("Incorrect exception message", "Missing required option: b", e.getMessage());
+            assertEquals("Missing required option: b", e.getMessage(), "Incorrect exception message");
             assertTrue(e.getMissingOptions().contains("b"));
         } catch (final ParseException e) {
             fail("expected to catch MissingOptionException");
@@ -420,7 +420,7 @@ public abstract class AbstractParserTestCase {
             parser.parse(options, args);
             fail("exception should have been thrown");
         } catch (final MissingOptionException e) {
-            assertEquals("Incorrect exception message", "Missing required options: b, c", e.getMessage());
+            assertEquals("Missing required options: b, c", e.getMessage(), "Incorrect exception message");
             assertTrue(e.getMissingOptions().contains("b"));
             assertTrue(e.getMissingOptions().contains("c"));
         } catch (final ParseException e) {
@@ -433,16 +433,16 @@ public abstract class AbstractParserTestCase {
         final String[] args = {"-c", "foobar", "-b", "toast"};
 
         CommandLine cl = parser.parse(options, args, true);
-        assertTrue("Confirm -c is set", cl.hasOption("c"));
-        assertEquals("Confirm  3 extra args: " + cl.getArgList().size(), 3, cl.getArgList().size());
+        assertTrue(cl.hasOption("c"), "Confirm -c is set");
+        assertEquals(3, cl.getArgList().size(), "Confirm  3 extra args: " + cl.getArgList().size());
 
         cl = parser.parse(options, cl.getArgs());
 
-        assertFalse("Confirm -c is not set", cl.hasOption("c"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertEquals("Confirm arg of -b", "toast", cl.getOptionValue("b"));
-        assertEquals("Confirm  1 extra arg: " + cl.getArgList().size(), 1, cl.getArgList().size());
-        assertEquals("Confirm  value of extra arg: " + cl.getArgList().get(0), "foobar", cl.getArgList().get(0));
+        assertFalse(cl.hasOption("c"), "Confirm -c is not set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertEquals("toast", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertEquals(1, cl.getArgList().size(), "Confirm  1 extra arg: " + cl.getArgList().size());
+        assertEquals("foobar", cl.getArgList().get(0), "Confirm  value of extra arg: " + cl.getArgList().get(0));
     }
 
     @Test
@@ -450,16 +450,16 @@ public abstract class AbstractParserTestCase {
         final String[] args = {"--copt", "foobar", "--bfile", "toast"};
 
         CommandLine cl = parser.parse(options, args, true);
-        assertTrue("Confirm -c is set", cl.hasOption("c"));
-        assertEquals("Confirm  3 extra args: " + cl.getArgList().size(), 3, cl.getArgList().size());
+        assertTrue(cl.hasOption("c"), "Confirm -c is set");
+        assertEquals(3, cl.getArgList().size(), "Confirm  3 extra args: " + cl.getArgList().size());
 
         cl = parser.parse(options, cl.getArgs());
 
-        assertFalse("Confirm -c is not set", cl.hasOption("c"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertEquals("Confirm arg of -b", "toast", cl.getOptionValue("b"));
-        assertEquals("Confirm  1 extra arg: " + cl.getArgList().size(), 1, cl.getArgList().size());
-        assertEquals("Confirm  value of extra arg: " + cl.getArgList().get(0), "foobar", cl.getArgList().get(0));
+        assertFalse(cl.hasOption("c"), "Confirm -c is not set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertEquals("toast", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertEquals(1, cl.getArgList().size(), "Confirm  1 extra arg: " + cl.getArgList().size());
+        assertEquals("foobar", cl.getArgList().get(0), "Confirm  value of extra arg: " + cl.getArgList().get(0));
     }
 
     @Test
@@ -488,7 +488,7 @@ public abstract class AbstractParserTestCase {
 
         CommandLine cmd = parse(parser, opts, new String[]{"-i"}, properties);
         assertTrue(cmd.hasOption("i"));
-        assertNull(null, cmd.getOptionValues("i"));
+        assertNull(cmd.getOptionValues("i"));
 
         cmd = parse(parser, opts, new String[]{"-i", "paper"}, properties);
         assertTrue(cmd.hasOption("i"));
@@ -512,7 +512,7 @@ public abstract class AbstractParserTestCase {
 
         CommandLine cmd = parse(parser, opts, new String[]{"-i"}, properties);
         assertTrue(cmd.hasOption("i"));
-        assertNull(null, cmd.getOptionValues("i"));
+        assertNull(cmd.getOptionValues("i"));
 
         cmd = parse(parser, opts, new String[]{"-i", "paper"}, properties);
         assertTrue(cmd.hasOption("i"));
@@ -538,10 +538,10 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -a is set", cl.hasOption("a"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertEquals("Confirm arg of -b", "file", cl.getOptionValue("b"));
-        assertTrue("Confirm NO of extra args", cl.getArgList().isEmpty());
+        assertTrue(cl.hasOption("a"), "Confirm -a is set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertEquals("file", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm NO of extra args");
     }
 
     @Test
@@ -555,7 +555,7 @@ public abstract class AbstractParserTestCase {
 
         parser.parse(options, new String[] {"-b"});
 
-        assertEquals("selected option", "b", group.getSelected());
+        assertEquals("b", group.getSelected(), "selected option");
     }
 
     @Test
@@ -570,7 +570,7 @@ public abstract class AbstractParserTestCase {
         final CommandLine cl = parser.parse(options, new String[] {"--bar"});
 
         assertTrue(cl.hasOption("bar"));
-        assertEquals("selected option", "bar", group.getSelected());
+        assertEquals("bar", group.getSelected(), "selected option");
     }
 
     @Test
@@ -583,8 +583,8 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm --version is set", cl.hasOption("version"));
-        assertFalse("Confirm -v is not set", cl.hasOption("v"));
+        assertTrue(cl.hasOption("version"), "Confirm --version is set");
+        assertFalse(cl.hasOption("v"), "Confirm -v is not set");
     }
 
     @Test
@@ -597,16 +597,16 @@ public abstract class AbstractParserTestCase {
         final CommandLine cl = parser.parse(options, args);
 
         final List<String> values = Arrays.asList(cl.getOptionValues("J"));
-        assertNotNull("null values", values);
-        assertEquals("number of values", 4, values.size());
-        assertEquals("value 1", "source", values.get(0));
-        assertEquals("value 2", "1.5", values.get(1));
-        assertEquals("value 3", "target", values.get(2));
-        assertEquals("value 4", "1.5", values.get(3));
+        assertNotNull(values, "null values");
+        assertEquals(4, values.size(), "number of values");
+        assertEquals("source", values.get(0), "value 1");
+        assertEquals("1.5", values.get(1), "value 2");
+        assertEquals("target", values.get(2), "value 3");
+        assertEquals("1.5", values.get(3), "value 4");
 
         final List<?> argsleft = cl.getArgList();
-        assertEquals("Should be 1 arg left", 1, argsleft.size());
-        assertEquals("Expecting foo", "foo", argsleft.get(0));
+        assertEquals(1, argsleft.size(), "Should be 1 arg left");
+        assertEquals("foo", argsleft.get(0), "Expecting foo");
     }
 
     @Test
@@ -619,13 +619,13 @@ public abstract class AbstractParserTestCase {
         final CommandLine cl = parser.parse(options, args);
 
         final Properties props = cl.getOptionProperties("D");
-        assertNotNull("null properties", props);
-        assertEquals("number of properties in " + props, 2, props.size());
-        assertEquals("property 1", "true", props.getProperty("param1"));
-        assertEquals("property 2", "value2", props.getProperty("param2"));
+        assertNotNull(props, "null properties");
+        assertEquals(2, props.size(), "number of properties in " + props);
+        assertEquals("true", props.getProperty("param1"), "property 1");
+        assertEquals("value2", props.getProperty("param2"), "property 2");
 
         final List<?> argsleft = cl.getArgList();
-        assertEquals("Should be no arg left", 0, argsleft.size());
+        assertEquals(0, argsleft.size(), "Should be no arg left");
     }
 
     @Test
@@ -809,7 +809,7 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm -b\"arg\" strips quotes",  "quoted string", cl.getOptionValue("b"));
+        assertEquals("quoted string", cl.getOptionValue("b"), "Confirm -b\"arg\" strips quotes");
     }
 
     @Test
@@ -818,7 +818,7 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm -b \"arg\" strips quotes",  "quoted string", cl.getOptionValue("b"));
+        assertEquals("quoted string", cl.getOptionValue("b"), "Confirm -b \"arg\" strips quotes");
     }
 
     @Test
@@ -868,11 +868,11 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -a is set", cl.hasOption("a"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertEquals("Confirm arg of -b", "toast", cl.getOptionValue("b"));
-        assertEquals("Confirm arg of --bfile", "toast", cl.getOptionValue("bfile"));
-        assertEquals("Confirm size of extra args", 2, cl.getArgList().size());
+        assertTrue(cl.hasOption("a"), "Confirm -a is set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertEquals("toast", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertEquals("toast", cl.getOptionValue("bfile"), "Confirm arg of --bfile");
+        assertEquals(2, cl.getArgList().size(), "Confirm size of extra args");
     }
 
     @Test
@@ -881,10 +881,10 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -a is set", cl.hasOption("a"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertEquals("Confirm arg of -b", "toast", cl.getOptionValue("b"));
-        assertEquals("Confirm size of extra args", 2, cl.getArgList().size());
+        assertTrue(cl.hasOption("a"), "Confirm -a is set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertEquals("toast", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertEquals(2, cl.getArgList().size(), "Confirm size of extra args");
     }
 
     @Test
@@ -893,11 +893,11 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -a is set", cl.hasOption("a"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertEquals("Confirm arg of -b", "-", cl.getOptionValue("b"));
-        assertEquals("Confirm 1 extra arg: " + cl.getArgList().size(), 1, cl.getArgList().size());
-        assertEquals("Confirm value of extra arg: " + cl.getArgList().get(0), "-", cl.getArgList().get(0));
+        assertTrue(cl.hasOption("a"), "Confirm -a is set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertEquals("-", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertEquals(1, cl.getArgList().size(), "Confirm 1 extra arg: " + cl.getArgList().size());
+        assertEquals("-", cl.getArgList().get(0), "Confirm value of extra arg: " + cl.getArgList().get(0));
     }
 
     @Test
@@ -906,9 +906,9 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args, true);
 
-        assertTrue("Confirm -b is set", cl.hasOption('b'));
-        assertEquals("Confirm -b is set", "foo", cl.getOptionValue('b'));
-        assertTrue("Confirm no extra args: " + cl.getArgList().size(), cl.getArgList().isEmpty());
+        assertTrue(cl.hasOption('b'), "Confirm -b is set");
+        assertEquals("foo", cl.getOptionValue('b'), "Confirm -b is set");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm no extra args: " + cl.getArgList().size());
     }
 
     @Test
@@ -917,9 +917,9 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args, true);
 
-        assertFalse("Confirm -a is not set", cl.hasOption("a"));
-        assertFalse("Confirm -b is not set", cl.hasOption("b"));
-        assertEquals("Confirm  3 extra args: " + cl.getArgList().size(), 3, cl.getArgList().size());
+        assertFalse(cl.hasOption("a"), "Confirm -a is not set");
+        assertFalse(cl.hasOption("b"), "Confirm -b is not set");
+        assertEquals(3, cl.getArgList().size(), "Confirm  3 extra args: " + cl.getArgList().size());
     }
 
     @Test
@@ -927,8 +927,8 @@ public abstract class AbstractParserTestCase {
         final String[] args = {"-z", "-a", "-btoast"};
 
         final CommandLine cl = parser.parse(options, args, true);
-        assertFalse("Confirm -a is not set", cl.hasOption("a"));
-        assertEquals("Confirm  3 extra args: " + cl.getArgList().size(), 3, cl.getArgList().size());
+        assertFalse(cl.hasOption("a"), "Confirm -a is not set");
+        assertEquals(3, cl.getArgList().size(), "Confirm  3 extra args: " + cl.getArgList().size());
     }
 
     @Test
@@ -936,8 +936,8 @@ public abstract class AbstractParserTestCase {
         final String[] args = {"-c", "foober", "-b", "toast"};
 
         final CommandLine cl = parser.parse(options, args, true);
-        assertTrue("Confirm -c is set", cl.hasOption("c"));
-        assertEquals("Confirm  3 extra args: " + cl.getArgList().size(), 3, cl.getArgList().size());
+        assertTrue(cl.hasOption("c"), "Confirm -c is set");
+        assertEquals(3, cl.getArgList().size(), "Confirm  3 extra args: " + cl.getArgList().size());
     }
 
     @Test
@@ -945,10 +945,10 @@ public abstract class AbstractParserTestCase {
         final String[] args = {"-azc"};
 
         final CommandLine cl = parser.parse(options, args, true);
-        assertTrue("Confirm -a is set", cl.hasOption("a"));
-        assertFalse("Confirm -c is not set", cl.hasOption("c"));
+        assertTrue(cl.hasOption("a"), "Confirm -a is set");
+        assertFalse(cl.hasOption("c"), "Confirm -c is not set");
 
-        assertEquals("Confirm  1 extra arg: " + cl.getArgList().size(), 1, cl.getArgList().size());
+        assertEquals(1, cl.getArgList().size(), "Confirm  1 extra arg: " + cl.getArgList().size());
         assertTrue(cl.getArgList().contains("zc"));
     }
 
@@ -957,16 +957,16 @@ public abstract class AbstractParserTestCase {
         final String[] args = {"-c", "foobar", "-btoast"};
 
         CommandLine cl = parser.parse(options, args, true);
-        assertTrue("Confirm -c is set", cl.hasOption("c"));
-        assertEquals("Confirm  2 extra args: " + cl.getArgList().size(), 2, cl.getArgList().size());
+        assertTrue(cl.hasOption("c"), "Confirm -c is set");
+        assertEquals(2, cl.getArgList().size(), "Confirm  2 extra args: " + cl.getArgList().size());
 
         cl = parser.parse(options, cl.getArgs());
 
-        assertFalse("Confirm -c is not set", cl.hasOption("c"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertEquals("Confirm arg of -b", "toast", cl.getOptionValue("b"));
-        assertEquals("Confirm  1 extra arg: " + cl.getArgList().size(), 1, cl.getArgList().size());
-        assertEquals("Confirm  value of extra arg: " + cl.getArgList().get(0), "foobar", cl.getArgList().get(0));
+        assertFalse(cl.hasOption("c"), "Confirm -c is not set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertEquals("toast", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertEquals(1, cl.getArgList().size(), "Confirm  1 extra arg: " + cl.getArgList().size());
+        assertEquals("foobar", cl.getArgList().get(0), "Confirm  value of extra arg: " + cl.getArgList().get(0));
     }
 
     @Test
@@ -979,7 +979,7 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm --version is set", cl.hasOption("version"));
+        assertTrue(cl.hasOption("version"), "Confirm --version is set");
     }
 
     @Test
@@ -992,7 +992,7 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm --version is set", cl.hasOption("version"));
+        assertTrue(cl.hasOption("version"), "Confirm --version is set");
     }
 
     @Test
@@ -1005,7 +1005,7 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm --verbose is set", cl.hasOption("verbose"));
+        assertTrue(cl.hasOption("verbose"), "Confirm --verbose is set");
         assertEquals("1", cl.getOptionValue("verbose"));
     }
 
@@ -1019,7 +1019,7 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm --verbose is set", cl.hasOption("verbose"));
+        assertTrue(cl.hasOption("verbose"), "Confirm --verbose is set");
         assertEquals("1", cl.getOptionValue("verbose"));
     }
 
@@ -1033,10 +1033,10 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -e is set", cl.hasOption("e"));
-        assertEquals("number of arg for -e", 2, cl.getOptionValues("e").length);
-        assertTrue("Confirm -f is set", cl.hasOption("f"));
-        assertEquals("number of arg for -f", 1, cl.getOptionValues("f").length);
+        assertTrue(cl.hasOption("e"), "Confirm -e is set");
+        assertEquals(2, cl.getOptionValues("e").length, "number of arg for -e");
+        assertTrue(cl.hasOption("f"), "Confirm -f is set");
+        assertEquals(1, cl.getOptionValues("f").length, "number of arg for -f");
     }
 
     @Test
@@ -1073,9 +1073,9 @@ public abstract class AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertFalse("Confirm -a is NOT set", cl.hasOption("a"));
-        assertTrue("Confirm -b is set", cl.hasOption("b"));
-        assertEquals("Confirm arg of -b", "file", cl.getOptionValue("b"));
-        assertTrue("Confirm NO of extra args", cl.getArgList().isEmpty());
+        assertFalse(cl.hasOption("a"), "Confirm -a is NOT set");
+        assertTrue(cl.hasOption("b"), "Confirm -b is set");
+        assertEquals("file", cl.getOptionValue("b"), "Confirm arg of -b");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm NO of extra args");
     }
 }

--- a/src/test/java/org/apache/commons/cli/ApplicationTest.java
+++ b/src/test/java/org/apache/commons/cli/ApplicationTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This is a collection of tests that test real world applications command lines.

--- a/src/test/java/org/apache/commons/cli/ArgumentIsOptionTest.java
+++ b/src/test/java/org/apache/commons/cli/ArgumentIsOptionTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class ArgumentIsOptionTest {
@@ -30,7 +30,7 @@ public class ArgumentIsOptionTest {
     private Options options;
     private CommandLineParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         options = new Options().addOption("p", false, "Option p").addOption("attr", true, "Option accepts argument");
         parser = new PosixParser();
@@ -41,9 +41,9 @@ public class ArgumentIsOptionTest {
         final String[] args = {"-p"};
 
         final CommandLine cl = parser.parse(options, args);
-        assertTrue("Confirm -p is set", cl.hasOption("p"));
-        assertFalse("Confirm -attr is not set", cl.hasOption("attr"));
-        assertEquals("Confirm all arguments recognized", 0, cl.getArgs().length);
+        assertTrue(cl.hasOption("p"), "Confirm -p is set");
+        assertFalse(cl.hasOption("attr"), "Confirm -attr is not set");
+        assertEquals(0, cl.getArgs().length, "Confirm all arguments recognized");
     }
 
     @Test
@@ -51,10 +51,10 @@ public class ArgumentIsOptionTest {
         final String[] args = {"-p", "-attr", "p"};
 
         final CommandLine cl = parser.parse(options, args);
-        assertTrue("Confirm -p is set", cl.hasOption("p"));
-        assertTrue("Confirm -attr is set", cl.hasOption("attr"));
-        assertEquals("Confirm arg of -attr", "p", cl.getOptionValue("attr"));
-        assertEquals("Confirm all arguments recognized", 0, cl.getArgs().length);
+        assertTrue(cl.hasOption("p"), "Confirm -p is set");
+        assertTrue(cl.hasOption("attr"), "Confirm -attr is set");
+        assertEquals("p", cl.getOptionValue("attr"), "Confirm arg of -attr");
+        assertEquals(0, cl.getArgs().length, "Confirm all arguments recognized");
     }
 
     @Test
@@ -62,9 +62,9 @@ public class ArgumentIsOptionTest {
         final String[] args = {"-attr", "p"};
 
         final CommandLine cl = parser.parse(options, args);
-        assertFalse("Confirm -p is set", cl.hasOption("p"));
-        assertTrue("Confirm -attr is set", cl.hasOption("attr"));
-        assertEquals("Confirm arg of -attr", "p", cl.getOptionValue("attr"));
-        assertEquals("Confirm all arguments recognized", 0, cl.getArgs().length);
+        assertFalse(cl.hasOption("p"), "Confirm -p is set");
+        assertTrue(cl.hasOption("attr"), "Confirm -attr is set");
+        assertEquals("p", cl.getOptionValue("attr"), "Confirm arg of -attr");
+        assertEquals(0, cl.getArgs().length, "Confirm all arguments recognized");
     }
 }

--- a/src/test/java/org/apache/commons/cli/BasicParserTest.java
+++ b/src/test/java/org/apache/commons/cli/BasicParserTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.cli;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class BasicParserTest extends AbstractParserTestCase {
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
         parser = new BasicParser();
@@ -32,163 +32,163 @@ public class BasicParserTest extends AbstractParserTestCase {
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testAmbiguousLongWithoutEqualSingleDash2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testAmbiguousPartialLongOption1() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testAmbiguousPartialLongOption2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testAmbiguousPartialLongOption3() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testAmbiguousPartialLongOption4() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testBursting() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testDoubleDash2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testLongOptionWithEqualsQuoteHandling() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testLongWithEqualDoubleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testLongWithEqualSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testLongWithoutEqualSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testMissingArgWithBursting() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser (CLI-184)")
+    @Disabled("not supported by the BasicParser (CLI-184)")
     public void testNegativeOption() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testPartialLongOptionSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testPropertiesOption1() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testPropertiesOption2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testShortOptionConcatenatedQuoteHandling() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testShortWithEqual() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testShortWithoutEqual() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testStopBursting() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testStopBursting2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testUnambiguousPartialLongOption1() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testUnambiguousPartialLongOption2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testUnambiguousPartialLongOption3() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testUnambiguousPartialLongOption4() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the BasicParser")
+    @Disabled("not supported by the BasicParser")
     public void testUnrecognizedOptionWithBursting() throws Exception {
     }
 }

--- a/src/test/java/org/apache/commons/cli/CommandLineTest.java
+++ b/src/test/java/org/apache/commons/cli/CommandLineTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Properties;
 import java.util.function.Supplier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class CommandLineTest {
@@ -78,14 +78,14 @@ public class CommandLineTest {
         final CommandLine cl = parser.parse(options, args);
 
         final Properties props = cl.getOptionProperties("D");
-        assertNotNull("null properties", props);
-        assertEquals("number of properties in " + props, 4, props.size());
-        assertEquals("property 1", "value1", props.getProperty("param1"));
-        assertEquals("property 2", "value2", props.getProperty("param2"));
-        assertEquals("property 3", "true", props.getProperty("param3"));
-        assertEquals("property 4", "value4", props.getProperty("param4"));
+        assertNotNull(props, "null properties");
+        assertEquals(4, props.size(), "number of properties in " + props);
+        assertEquals("value1", props.getProperty("param1"), "property 1");
+        assertEquals("value2", props.getProperty("param2"), "property 2");
+        assertEquals("true", props.getProperty("param3"), "property 3");
+        assertEquals("value4", props.getProperty("param4"), "property 4");
 
-        assertEquals("property with long format", "bar", cl.getOptionProperties("property").getProperty("foo"));
+        assertEquals("bar", cl.getOptionProperties("property").getProperty("foo"), "property with long format");
     }
 
     @Test
@@ -102,14 +102,14 @@ public class CommandLineTest {
         final CommandLine cl = parser.parse(options, args);
 
         final Properties props = cl.getOptionProperties(optionD);
-        assertNotNull("null properties", props);
-        assertEquals("number of properties in " + props, 4, props.size());
-        assertEquals("property 1", "value1", props.getProperty("param1"));
-        assertEquals("property 2", "value2", props.getProperty("param2"));
-        assertEquals("property 3", "true", props.getProperty("param3"));
-        assertEquals("property 4", "value4", props.getProperty("param4"));
+        assertNotNull(props, "null properties");
+        assertEquals(4, props.size(), "number of properties in " + props);
+        assertEquals("value1", props.getProperty("param1"), "property 1");
+        assertEquals("value2", props.getProperty("param2"), "property 2");
+        assertEquals("true", props.getProperty("param3"), "property 3");
+        assertEquals("value4", props.getProperty("param4"), "property 4");
 
-        assertEquals("property with long format", "bar", cl.getOptionProperties(optionProperty).getProperty("foo"));
+        assertEquals("bar", cl.getOptionProperties(optionProperty).getProperty("foo"), "property with long format");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/src/test/java/org/apache/commons/cli/DefaultParserTest.java
+++ b/src/test/java/org/apache/commons/cli/DefaultParserTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DefaultParserTest extends AbstractParserTestCase {
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
         parser = new DefaultParser();
@@ -47,7 +47,7 @@ public class DefaultParserTest extends AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm --bfile \"arg\" keeps quotes",  "\"quoted string\"", cl.getOptionValue("b"));
+        assertEquals("\"quoted string\"", cl.getOptionValue("b"), "Confirm --bfile \"arg\" keeps quotes");
     }
 
     @Test
@@ -57,7 +57,7 @@ public class DefaultParserTest extends AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm --bfile \"arg\" strips quotes",  "quoted string", cl.getOptionValue("b"));
+        assertEquals("quoted string", cl.getOptionValue("b"), "Confirm --bfile \"arg\" strips quotes");
     }
 
     @Override
@@ -67,7 +67,7 @@ public class DefaultParserTest extends AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm --bfile=\"arg\" strips quotes",  "\"quoted string\"", cl.getOptionValue("b"));
+        assertEquals("\"quoted string\"", cl.getOptionValue("b"), "Confirm --bfile=\"arg\" strips quotes");
     }
 
     @Test
@@ -77,7 +77,7 @@ public class DefaultParserTest extends AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm --bfile=\"arg\" keeps quotes",  "\"quoted string\"", cl.getOptionValue("b"));
+        assertEquals("\"quoted string\"", cl.getOptionValue("b"), "Confirm --bfile=\"arg\" keeps quotes");
     }
 
     @Test
@@ -87,7 +87,7 @@ public class DefaultParserTest extends AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm --bfile=\"arg\" strips quotes",  "quoted string", cl.getOptionValue("b"));
+        assertEquals("quoted string", cl.getOptionValue("b"), "Confirm --bfile=\"arg\" strips quotes");
     }
 
     @Override
@@ -98,7 +98,7 @@ public class DefaultParserTest extends AbstractParserTestCase {
         final CommandLine cl = parser.parse(options, args);
 
         //This is behavior is not consistent with the other parsers, but is required for backwards compatibility
-        assertEquals("Confirm -b\"arg\" keeps quotes",  "\"quoted string\"", cl.getOptionValue("b"));
+        assertEquals("\"quoted string\"", cl.getOptionValue("b"), "Confirm -b\"arg\" keeps quotes");
     }
 
     @Test
@@ -108,7 +108,7 @@ public class DefaultParserTest extends AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm -b \"arg\" keeps quotes",  "\"quoted string\"", cl.getOptionValue("b"));
+        assertEquals("\"quoted string\"", cl.getOptionValue("b"), "Confirm -b \"arg\" keeps quotes");
     }
 
     @Test
@@ -118,6 +118,6 @@ public class DefaultParserTest extends AbstractParserTestCase {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertEquals("Confirm -b \"arg\" strips quotes",  "quoted string", cl.getOptionValue("b"));
+        assertEquals("quoted string", cl.getOptionValue("b"), "Confirm -b \"arg\" strips quotes");
     }
 }

--- a/src/test/java/org/apache/commons/cli/DisablePartialMatchingTest.java
+++ b/src/test/java/org/apache/commons/cli/DisablePartialMatchingTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DisablePartialMatchingTest {
     @Test
@@ -35,9 +35,9 @@ public class DisablePartialMatchingTest {
 
         final CommandLine line = parser.parse(options, new String[] {"-de", "--option=foobar"});
 
-        assertTrue("There should be an option debug in any case...", line.hasOption("debug"));
-        assertTrue("There should be an extract option because partial matching is off", line.hasOption("extract"));
-        assertTrue("There should be an option option with a argument value", line.hasOption("option"));
+        assertTrue(line.hasOption("debug"), "There should be an option debug in any case...");
+        assertTrue(line.hasOption("extract"), "There should be an extract option because partial matching is off");
+        assertTrue(line.hasOption("option"), "There should be an option option with a argument value");
     }
 
     @Test
@@ -52,8 +52,8 @@ public class DisablePartialMatchingTest {
 
         final CommandLine line = parser.parse(options, new String[] {"-de", "--option=foobar"});
 
-        assertTrue("There should be an option debug in any case...", line.hasOption("debug"));
-        assertFalse("There should not be an extract option because partial matching only selects debug", line.hasOption("extract"));
-        assertTrue("There should be an option option with a argument value", line.hasOption("option"));
+        assertTrue(line.hasOption("debug"), "There should be an option debug in any case...");
+        assertFalse(line.hasOption("extract"), "There should not be an extract option because partial matching only selects debug");
+        assertTrue(line.hasOption("option"), "There should be an option option with a argument value");
     }
 }

--- a/src/test/java/org/apache/commons/cli/GnuParserTest.java
+++ b/src/test/java/org/apache/commons/cli/GnuParserTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.cli;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class GnuParserTest extends AbstractParserTestCase {
     @Override
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
         parser = new GnuParser();
@@ -32,133 +32,133 @@ public class GnuParserTest extends AbstractParserTestCase {
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testAmbiguousLongWithoutEqualSingleDash2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testAmbiguousPartialLongOption1() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testAmbiguousPartialLongOption2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testAmbiguousPartialLongOption3() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testAmbiguousPartialLongOption4() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testBursting() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testDoubleDash2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testLongWithoutEqualSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testLongWithUnexpectedArgument1() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testLongWithUnexpectedArgument2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testMissingArgWithBursting() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser (CLI-184)")
+    @Disabled("not supported by the GnuParser (CLI-184)")
     public void testNegativeOption() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testPartialLongOptionSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testShortWithUnexpectedArgument() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testStopBursting() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testStopBursting2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testUnambiguousPartialLongOption1() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testUnambiguousPartialLongOption2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testUnambiguousPartialLongOption3() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testUnambiguousPartialLongOption4() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the GnuParser")
+    @Disabled("not supported by the GnuParser")
     public void testUnrecognizedOptionWithBursting() throws Exception {
     }
 }

--- a/src/test/java/org/apache/commons/cli/HelpFormatterTest.java
+++ b/src/test/java/org/apache/commons/cli/HelpFormatterTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for the HelpFormatter class.
@@ -38,28 +38,28 @@ public class HelpFormatterTest {
         final HelpFormatter formatter = new HelpFormatter();
 
         formatter.setArgName("argname");
-        assertEquals("arg name", "argname", formatter.getArgName());
+        assertEquals("argname", formatter.getArgName(), "arg name");
 
         formatter.setDescPadding(3);
-        assertEquals("desc padding", 3, formatter.getDescPadding());
+        assertEquals(3, formatter.getDescPadding(), "desc padding");
 
         formatter.setLeftPadding(7);
-        assertEquals("left padding", 7, formatter.getLeftPadding());
+        assertEquals(7, formatter.getLeftPadding(), "left padding");
 
         formatter.setLongOptPrefix("~~");
-        assertEquals("long opt prefix", "~~", formatter.getLongOptPrefix());
+        assertEquals("~~", formatter.getLongOptPrefix(), "long opt prefix");
 
         formatter.setNewLine("\n");
-        assertEquals("new line", "\n", formatter.getNewLine());
+        assertEquals("\n", formatter.getNewLine(), "new line");
 
         formatter.setOptPrefix("~");
-        assertEquals("opt prefix", "~", formatter.getOptPrefix());
+        assertEquals("~", formatter.getOptPrefix(), "opt prefix");
 
         formatter.setSyntaxPrefix("-> ");
-        assertEquals("syntax prefix", "-> ", formatter.getSyntaxPrefix());
+        assertEquals("-> ", formatter.getSyntaxPrefix(), "syntax prefix");
 
         formatter.setWidth(80);
-        assertEquals("width", 80, formatter.getWidth());
+        assertEquals(80, formatter.getWidth(), "width");
     }
 
     @Test
@@ -73,14 +73,14 @@ public class HelpFormatterTest {
         options = new Options().addOption("a", false, "aaaa aaaa aaaa aaaa aaaa");
         hf.printUsage(pw, 60, "app", options);
         pw.flush();
-        assertEquals("simple auto usage", expected, out.toString().trim());
+        assertEquals(expected, out.toString().trim(), "simple auto usage");
         out.reset();
 
         expected = "usage: app [-a] [-b]";
         options = new Options().addOption("a", false, "aaaa aaaa aaaa aaaa aaaa").addOption("b", false, "bbb");
         hf.printUsage(pw, 60, "app", options);
         pw.flush();
-        assertEquals("simple auto usage", expected, out.toString().trim());
+        assertEquals(expected, out.toString().trim(), "simple auto usage");
         out.reset();
     }
 
@@ -106,25 +106,25 @@ public class HelpFormatterTest {
 
         String text = "This is a test.";
         // text width should be max 8; the wrap position is 7
-        assertEquals("wrap position", 7, hf.findWrapPos(text, 8, 0));
+        assertEquals(7, hf.findWrapPos(text, 8, 0), "wrap position");
 
         // starting from 8 must give -1 - the wrap pos is after end
-        assertEquals("wrap position 2", -1, hf.findWrapPos(text, 8, 8));
+        assertEquals(-1, hf.findWrapPos(text, 8, 8), "wrap position 2");
 
         // words longer than the width are cut
         text = "aaaa aa";
-        assertEquals("wrap position 3", 3, hf.findWrapPos(text, 3, 0));
+        assertEquals(3, hf.findWrapPos(text, 3, 0), "wrap position 3");
 
         // last word length is equal to the width
         text = "aaaaaa aaaaaa";
-        assertEquals("wrap position 4", 6, hf.findWrapPos(text, 6, 0));
-        assertEquals("wrap position 4", -1, hf.findWrapPos(text, 6, 7));
+        assertEquals(6, hf.findWrapPos(text, 6, 0), "wrap position 4");
+        assertEquals(-1, hf.findWrapPos(text, 6, 7), "wrap position 4");
 
         text = "aaaaaa\n aaaaaa";
-        assertEquals("wrap position 5", 7, hf.findWrapPos(text, 6, 0));
+        assertEquals(7, hf.findWrapPos(text, 6, 0), "wrap position 5");
 
         text = "aaaaaa\t aaaaaa";
-        assertEquals("wrap position 6", 7, hf.findWrapPos(text, 6, 0));
+        assertEquals(7, hf.findWrapPos(text, 6, 0), "wrap position 6");
     }
 
     @Test
@@ -316,7 +316,7 @@ public class HelpFormatterTest {
                           "-ab" + EOL +
                           EOL;
         pw.flush();
-        assertEquals("footer newline", expected, out.toString());
+        assertEquals(expected, out.toString(), "footer newline");
     }
 
     @Test
@@ -343,7 +343,7 @@ public class HelpFormatterTest {
                           "-ab" + EOL +
                           "footer" + EOL;
         pw.flush();
-        assertEquals("header newline", expected, out.toString());
+        assertEquals(expected, out.toString(), "header newline");
     }
 
     @Test
@@ -396,32 +396,32 @@ public class HelpFormatterTest {
         options = new Options().addOption("a", false, "aaaa aaaa aaaa aaaa aaaa");
         expected = lpad + "-a" + dpad + "aaaa aaaa aaaa aaaa aaaa";
         hf.renderOptions(sb, 60, options, leftPad, descPad);
-        assertEquals("simple non-wrapped option", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "simple non-wrapped option");
 
         int nextLineTabStop = leftPad + descPad + "-a".length();
         expected = lpad + "-a" + dpad + "aaaa aaaa aaaa" + EOL + hf.createPadding(nextLineTabStop) + "aaaa aaaa";
         sb.setLength(0);
         hf.renderOptions(sb, nextLineTabStop + 17, options, leftPad, descPad);
-        assertEquals("simple wrapped option", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "simple wrapped option");
 
         options = new Options().addOption("a", "aaa", false, "dddd dddd dddd dddd");
         expected = lpad + "-a,--aaa" + dpad + "dddd dddd dddd dddd";
         sb.setLength(0);
         hf.renderOptions(sb, 60, options, leftPad, descPad);
-        assertEquals("long non-wrapped option", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "long non-wrapped option");
 
         nextLineTabStop = leftPad + descPad + "-a,--aaa".length();
         expected = lpad + "-a,--aaa" + dpad + "dddd dddd" + EOL + hf.createPadding(nextLineTabStop) + "dddd dddd";
         sb.setLength(0);
         hf.renderOptions(sb, 25, options, leftPad, descPad);
-        assertEquals("long wrapped option", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "long wrapped option");
 
         options = new Options().addOption("a", "aaa", false, "dddd dddd dddd dddd").addOption("b", false, "feeee eeee eeee eeee");
         expected = lpad + "-a,--aaa" + dpad + "dddd dddd" + EOL + hf.createPadding(nextLineTabStop) + "dddd dddd" + EOL + lpad + "-b      " + dpad
             + "feeee eeee" + EOL + hf.createPadding(nextLineTabStop) + "eeee eeee";
         sb.setLength(0);
         hf.renderOptions(sb, 25, options, leftPad, descPad);
-        assertEquals("multiple wrapped options", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "multiple wrapped options");
     }
 
     @Test
@@ -525,7 +525,7 @@ public class HelpFormatterTest {
 
         final StringBuffer sb = new StringBuffer();
         new HelpFormatter().renderWrappedText(sb, width, padding, expected);
-        assertEquals("multi line text", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "multi line text");
     }
 
     @Test
@@ -544,7 +544,7 @@ public class HelpFormatterTest {
 
         final StringBuffer sb = new StringBuffer();
         new HelpFormatter().renderWrappedText(sb, width, padding, text);
-        assertEquals("multi-line padded text", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "multi-line padded text");
     }
 
     @Test
@@ -557,7 +557,7 @@ public class HelpFormatterTest {
 
         final StringBuffer sb = new StringBuffer();
         new HelpFormatter().renderWrappedText(sb, width, padding, text);
-        assertEquals("single line text", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "single line text");
     }
 
     @Test
@@ -570,7 +570,7 @@ public class HelpFormatterTest {
 
         final StringBuffer sb = new StringBuffer();
         new HelpFormatter().renderWrappedText(sb, width, padding, text);
-        assertEquals("single line padded text", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "single line padded text");
     }
 
     @Test
@@ -588,7 +588,7 @@ public class HelpFormatterTest {
 
         final StringBuffer sb = new StringBuffer();
         new HelpFormatter().renderWrappedText(sb, width, padding, text);
-        assertEquals("single line padded text 2", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "single line padded text 2");
     }
 
     @Test
@@ -600,7 +600,7 @@ public class HelpFormatterTest {
 
         final StringBuffer sb = new StringBuffer();
         new HelpFormatter().renderWrappedText(sb, width, padding, text);
-        assertEquals("cut and wrap", expected, sb.toString());
+        assertEquals(expected, sb.toString(), "cut and wrap");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/OptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionBuilderTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // OptionBuilder is marked deprecated
 public class OptionBuilderTest {
@@ -53,7 +53,7 @@ public class OptionBuilderTest {
         } catch (final IllegalArgumentException e) {
             // expected
         }
-        assertNull("we inherited a description", OptionBuilder.create('x').getDescription());
+        assertNull(OptionBuilder.create('x').getDescription(), "we inherited a description");
 
         try {
             OptionBuilder.withDescription("JUnit").create();
@@ -61,7 +61,7 @@ public class OptionBuilderTest {
         } catch (final IllegalArgumentException e) {
             // expected
         }
-        assertNull("we inherited a description", OptionBuilder.create('x').getDescription());
+        assertNull(OptionBuilder.create('x').getDescription(), "we inherited a description");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/OptionGroupTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionGroupTest.java
@@ -17,23 +17,23 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Properties;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class OptionGroupTest {
     private Options options;
     private final Parser parser = new PosixParser();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final Option file = new Option("f", "file", false, "file to process");
         final Option dir = new Option("d", "directory", false, "directory to process");
@@ -66,7 +66,7 @@ public class OptionGroupTest {
         group.addOption(OptionBuilder.create('a'));
         group.addOption(OptionBuilder.create('b'));
 
-        assertNotNull("null names", group.getNames());
+        assertNotNull(group.getNames(), "null names");
         assertEquals(2, group.getNames().size());
         assertTrue(group.getNames().contains("a"));
         assertTrue(group.getNames().contains("b"));
@@ -78,12 +78,12 @@ public class OptionGroupTest {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertFalse("Confirm -r is NOT set", cl.hasOption("r"));
-        assertFalse("Confirm -f is NOT set", cl.hasOption("f"));
-        assertFalse("Confirm -d is NOT set", cl.hasOption("d"));
-        assertFalse("Confirm -s is NOT set", cl.hasOption("s"));
-        assertFalse("Confirm -c is NOT set", cl.hasOption("c"));
-        assertEquals("Confirm TWO extra args", 2, cl.getArgList().size());
+        assertFalse(cl.hasOption("r"), "Confirm -r is NOT set");
+        assertFalse(cl.hasOption("f"), "Confirm -f is NOT set");
+        assertFalse(cl.hasOption("d"), "Confirm -d is NOT set");
+        assertFalse(cl.hasOption("s"), "Confirm -s is NOT set");
+        assertFalse(cl.hasOption("c"), "Confirm -c is NOT set");
+        assertEquals(2, cl.getArgList().size(), "Confirm TWO extra args");
     }
 
     @Test
@@ -92,12 +92,12 @@ public class OptionGroupTest {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertFalse("Confirm -r is NOT set", cl.hasOption("r"));
-        assertTrue("Confirm -f is set", cl.hasOption("f"));
-        assertFalse("Confirm -d is NOT set", cl.hasOption("d"));
-        assertFalse("Confirm -s is NOT set", cl.hasOption("s"));
-        assertFalse("Confirm -c is NOT set", cl.hasOption("c"));
-        assertTrue("Confirm no extra args", cl.getArgList().isEmpty());
+        assertFalse(cl.hasOption("r"), "Confirm -r is NOT set");
+        assertTrue(cl.hasOption("f"), "Confirm -f is set");
+        assertFalse(cl.hasOption("d"), "Confirm -d is NOT set");
+        assertFalse(cl.hasOption("s"), "Confirm -s is NOT set");
+        assertFalse(cl.hasOption("c"), "Confirm -c is NOT set");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm no extra args");
     }
 
     @Test
@@ -106,12 +106,12 @@ public class OptionGroupTest {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -r is set", cl.hasOption("r"));
-        assertFalse("Confirm -f is NOT set", cl.hasOption("f"));
-        assertFalse("Confirm -d is NOT set", cl.hasOption("d"));
-        assertFalse("Confirm -s is NOT set", cl.hasOption("s"));
-        assertFalse("Confirm -c is NOT set", cl.hasOption("c"));
-        assertTrue("Confirm no extra args", cl.getArgList().isEmpty());
+        assertTrue(cl.hasOption("r"), "Confirm -r is set");
+        assertFalse(cl.hasOption("f"), "Confirm -f is NOT set");
+        assertFalse(cl.hasOption("d"), "Confirm -d is NOT set");
+        assertFalse(cl.hasOption("s"), "Confirm -s is NOT set");
+        assertFalse(cl.hasOption("c"), "Confirm -c is NOT set");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm no extra args");
     }
 
     @Test
@@ -120,12 +120,12 @@ public class OptionGroupTest {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertFalse("Confirm -r is NOT set", cl.hasOption("r"));
-        assertTrue("Confirm -f is set", cl.hasOption("f"));
-        assertFalse("Confirm -d is NOT set", cl.hasOption("d"));
-        assertFalse("Confirm -s is NOT set", cl.hasOption("s"));
-        assertFalse("Confirm -c is NOT set", cl.hasOption("c"));
-        assertTrue("Confirm no extra args", cl.getArgList().isEmpty());
+        assertFalse(cl.hasOption("r"), "Confirm -r is NOT set");
+        assertTrue(cl.hasOption("f"), "Confirm -f is set");
+        assertFalse(cl.hasOption("d"), "Confirm -d is NOT set");
+        assertFalse(cl.hasOption("s"), "Confirm -s is NOT set");
+        assertFalse(cl.hasOption("c"), "Confirm -c is NOT set");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm no extra args");
     }
 
     @Test
@@ -155,9 +155,9 @@ public class OptionGroupTest {
             parser.parse(options, args);
             fail("two arguments from group not allowed");
         } catch (final AlreadySelectedException e) {
-            assertNotNull("null option group", e.getOptionGroup());
-            assertEquals("selected option", "f", e.getOptionGroup().getSelected());
-            assertEquals("option", "d", e.getOption().getOpt());
+            assertNotNull(e.getOptionGroup(), "null option group");
+            assertEquals("f", e.getOptionGroup().getSelected(), "selected option");
+            assertEquals("d", e.getOption().getOpt(), "option");
         }
     }
 
@@ -166,12 +166,12 @@ public class OptionGroupTest {
         final String[] args = {"-f", "-s"};
 
         final CommandLine cl = parser.parse(options, args);
-        assertFalse("Confirm -r is NOT set", cl.hasOption("r"));
-        assertTrue("Confirm -f is set", cl.hasOption("f"));
-        assertFalse("Confirm -d is NOT set", cl.hasOption("d"));
-        assertTrue("Confirm -s is set", cl.hasOption("s"));
-        assertFalse("Confirm -c is NOT set", cl.hasOption("c"));
-        assertTrue("Confirm NO extra args", cl.getArgList().isEmpty());
+        assertFalse(cl.hasOption("r"), "Confirm -r is NOT set");
+        assertTrue(cl.hasOption("f"), "Confirm -f is set");
+        assertFalse(cl.hasOption("d"), "Confirm -d is NOT set");
+        assertTrue(cl.hasOption("s"), "Confirm -s is set");
+        assertFalse(cl.hasOption("c"), "Confirm -c is NOT set");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm NO extra args");
     }
 
     @Test
@@ -182,9 +182,9 @@ public class OptionGroupTest {
             parser.parse(options, args);
             fail("two arguments from group not allowed");
         } catch (final AlreadySelectedException e) {
-            assertNotNull("null option group", e.getOptionGroup());
-            assertEquals("selected option", "f", e.getOptionGroup().getSelected());
-            assertEquals("option", "d", e.getOption().getOpt());
+            assertNotNull(e.getOptionGroup(), "null option group");
+            assertEquals("f", e.getOptionGroup().getSelected(), "selected option");
+            assertEquals("d", e.getOption().getOpt(), "option");
         }
     }
 
@@ -206,12 +206,12 @@ public class OptionGroupTest {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -r is set", cl.hasOption("r"));
-        assertTrue("Confirm -f is set", cl.hasOption("f"));
-        assertFalse("Confirm -d is NOT set", cl.hasOption("d"));
-        assertFalse("Confirm -s is NOT set", cl.hasOption("s"));
-        assertFalse("Confirm -c is NOT set", cl.hasOption("c"));
-        assertTrue("Confirm no extra args", cl.getArgList().isEmpty());
+        assertTrue(cl.hasOption("r"), "Confirm -r is set");
+        assertTrue(cl.hasOption("f"), "Confirm -f is set");
+        assertFalse(cl.hasOption("d"), "Confirm -d is NOT set");
+        assertFalse(cl.hasOption("s"), "Confirm -s is NOT set");
+        assertFalse(cl.hasOption("c"), "Confirm -c is NOT set");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm no extra args");
     }
 
     @Test
@@ -220,20 +220,20 @@ public class OptionGroupTest {
 
         final CommandLine cl = parser.parse(options, args);
 
-        assertTrue("Confirm -r is set", cl.hasOption("r"));
-        assertTrue("Confirm -f is set", cl.hasOption("f"));
-        assertFalse("Confirm -d is NOT set", cl.hasOption("d"));
-        assertFalse("Confirm -s is NOT set", cl.hasOption("s"));
-        assertFalse("Confirm -c is NOT set", cl.hasOption("c"));
-        assertTrue("Confirm no extra args", cl.getArgList().isEmpty());
+        assertTrue(cl.hasOption("r"), "Confirm -r is set");
+        assertTrue(cl.hasOption("f"), "Confirm -f is set");
+        assertFalse(cl.hasOption("d"), "Confirm -d is NOT set");
+        assertFalse(cl.hasOption("s"), "Confirm -s is NOT set");
+        assertFalse(cl.hasOption("c"), "Confirm -c is NOT set");
+        assertTrue(cl.getArgList().isEmpty(), "Confirm no extra args");
     }
 
     @Test
     public void testValidLongOnlyOptions() throws Exception {
         final CommandLine cl1 = parser.parse(options, new String[] {"--export"});
-        assertTrue("Confirm --export is set", cl1.hasOption("export"));
+        assertTrue(cl1.hasOption("export"), "Confirm --export is set");
 
         final CommandLine cl2 = parser.parse(options, new String[] {"--import"});
-        assertTrue("Confirm --import is set", cl2.hasOption("import"));
+        assertTrue(cl2.hasOption("import"), "Confirm --import is set");
     }
 }

--- a/src/test/java/org/apache/commons/cli/OptionTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OptionTest {
 

--- a/src/test/java/org/apache/commons/cli/OptionsTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionsTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -31,7 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class OptionsTest {
@@ -126,7 +126,7 @@ public class OptionsTest {
         final Options opts = new Options();
         opts.addOption("a", "--a", false, "toggle -a");
         opts.addOption("a", "--a", false, "toggle -a*");
-        assertEquals("last one in wins", "toggle -a*", opts.getOption("a").getDescription());
+        assertEquals("toggle -a*", opts.getOption("a").getDescription(), "last one in wins");
     }
 
     @Test
@@ -135,7 +135,7 @@ public class OptionsTest {
         opts.addOption("a", false, "toggle -a");
         opts.addOption("a", true, "toggle -a*");
 
-        assertEquals("last one in wins", "toggle -a*", opts.getOption("a").getDescription());
+        assertEquals("toggle -a*", opts.getOption("a").getDescription(), "last one in wins");
     }
 
     @Test
@@ -201,8 +201,8 @@ public class OptionsTest {
 
         final Collection<Option> helpOptions = options.helpOptions();
 
-        assertTrue("Everything in all should be in help", helpOptions.containsAll(allOptions));
-        assertTrue("Everything in help should be in all", allOptions.containsAll(helpOptions));
+        assertTrue(helpOptions.containsAll(allOptions), "Everything in all should be in help");
+        assertTrue(allOptions.containsAll(helpOptions), "Everything in help should be in all");
     }
 
     @Test
@@ -262,8 +262,8 @@ public class OptionsTest {
         options.addOption("b", "bar", false, "Bar");
 
         final String s = options.toString();
-        assertNotNull("null string returned", s);
-        assertTrue("foo option missing", s.toLowerCase().contains("foo"));
-        assertTrue("bar option missing", s.toLowerCase().contains("bar"));
+        assertNotNull(s, "null string returned");
+        assertTrue(s.toLowerCase().contains("foo"), "foo option missing");
+        assertTrue(s.toLowerCase().contains("bar"), "bar option missing");
     }
 }

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -31,15 +31,15 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Vector;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for the PatternOptionBuilder class.
  */
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class PatternOptionBuilderTest {
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         PatternOptionBuilder.registerTypes();
     }
@@ -50,8 +50,8 @@ public class PatternOptionBuilderTest {
         final CommandLineParser parser = new PosixParser();
         final CommandLine line = parser.parse(options, new String[] {"-c", "java.util.Calendar", "-d", "System.DateTime"});
 
-        assertEquals("c value", Calendar.class, line.getOptionObject("c"));
-        assertNull("d value", line.getOptionObject("d"));
+        assertEquals(Calendar.class, line.getOptionObject("c"), "c value");
+        assertNull(line.getOptionObject("d"), "d value");
     }
 
     @Test
@@ -68,8 +68,8 @@ public class PatternOptionBuilderTest {
 
         final Object parsedReadableFileStream = line.getOptionObject("g");
 
-        assertNotNull("option g not parsed", parsedReadableFileStream);
-        assertTrue("option g not FileInputStream", parsedReadableFileStream instanceof FileInputStream);
+        assertNotNull(parsedReadableFileStream, "option g not parsed");
+        assertTrue(parsedReadableFileStream instanceof FileInputStream, "option g not FileInputStream");
     }
 
     @Test
@@ -78,7 +78,7 @@ public class PatternOptionBuilderTest {
         final CommandLineParser parser = new PosixParser();
         final CommandLine line = parser.parse(options, new String[] {"-f", "non-existing.file"});
 
-        assertNull("option f parsed", line.getOptionObject("f"));
+        assertNull(line.getOptionObject("f"), "option f parsed");
     }
 
     @Test
@@ -89,13 +89,13 @@ public class PatternOptionBuilderTest {
         //assertThrows(ParseException.class, () -> parser.parse(options, new String[] {"-n", "1", "-d", "2.1", "-x", "3,5"}));
 
         final CommandLine line = parser.parse(options, new String[] {"-n", "1", "-d", "2.1", "-x", "3,5"});
-        assertEquals("n object class", Long.class, line.getOptionObject("n").getClass());
-        assertEquals("n value", Long.valueOf(1), line.getOptionObject("n"));
+        assertEquals(Long.class, line.getOptionObject("n").getClass(), "n object class");
+        assertEquals(Long.valueOf(1), line.getOptionObject("n"), "n value");
 
-        assertEquals("d object class", Double.class, line.getOptionObject("d").getClass());
-        assertEquals("d value", Double.valueOf(2.1), line.getOptionObject("d"));
+        assertEquals(Double.class, line.getOptionObject("d").getClass(), "d object class");
+        assertEquals(Double.valueOf(2.1), line.getOptionObject("d"), "d value");
 
-        assertNull("x object", line.getOptionObject("x"));
+        assertNull(line.getOptionObject("x"), "x object");
     }
 
     @Test
@@ -104,9 +104,9 @@ public class PatternOptionBuilderTest {
         final CommandLineParser parser = new PosixParser();
         final CommandLine line = parser.parse(options, new String[] {"-o", "java.lang.String", "-i", "java.util.Calendar", "-n", "System.DateTime"});
 
-        assertEquals("o value", "", line.getOptionObject("o"));
-        assertNull("i value", line.getOptionObject("i"));
-        assertNull("n value", line.getOptionObject("n"));
+        assertEquals("", line.getOptionObject("o"), "o value");
+        assertNull(line.getOptionObject("i"), "i value");
+        assertNull(line.getOptionObject("n"), "n value");
     }
 
     @Test
@@ -132,36 +132,36 @@ public class PatternOptionBuilderTest {
         final CommandLineParser parser = new PosixParser();
         final CommandLine line = parser.parse(options, args);
 
-        assertEquals("flag a", "foo", line.getOptionValue("a"));
-        assertEquals("string flag a", "foo", line.getOptionObject("a"));
-        assertEquals("object flag b", new Vector<>(), line.getOptionObject("b"));
-        assertTrue("boolean true flag c", line.hasOption("c"));
-        assertFalse("boolean false flag d", line.hasOption("d"));
-        assertEquals("file flag e", new File("build.xml"), line.getOptionObject("e"));
-        assertEquals("class flag f", Calendar.class, line.getOptionObject("f"));
-        assertEquals("number flag n", Double.valueOf(4.5), line.getOptionObject("n"));
-        assertEquals("url flag t", new URL("https://commons.apache.org"), line.getOptionObject("t"));
+        assertEquals("foo", line.getOptionValue("a"), "flag a");
+        assertEquals("foo", line.getOptionObject("a"), "string flag a");
+        assertEquals(new Vector<>(), line.getOptionObject("b"), "object flag b");
+        assertTrue(line.hasOption("c"), "boolean true flag c");
+        assertFalse(line.hasOption("d"), "boolean false flag d");
+        assertEquals(new File("build.xml"), line.getOptionObject("e"), "file flag e");
+        assertEquals(Calendar.class, line.getOptionObject("f"), "class flag f");
+        assertEquals(Double.valueOf(4.5), line.getOptionObject("n"), "number flag n");
+        assertEquals(new URL("https://commons.apache.org"), line.getOptionObject("t"), "url flag t");
 
         // tests the char methods of CommandLine that delegate to the String methods
-        assertEquals("flag a", "foo", line.getOptionValue('a'));
-        assertEquals("string flag a", "foo", line.getOptionObject('a'));
-        assertEquals("object flag b", new Vector<>(), line.getOptionObject('b'));
-        assertTrue("boolean true flag c", line.hasOption('c'));
-        assertFalse("boolean false flag d", line.hasOption('d'));
-        assertEquals("file flag e", new File("build.xml"), line.getOptionObject('e'));
-        assertEquals("class flag f", Calendar.class, line.getOptionObject('f'));
-        assertEquals("number flag n", Double.valueOf(4.5), line.getOptionObject('n'));
-        assertEquals("url flag t", new URL("https://commons.apache.org"), line.getOptionObject('t'));
+        assertEquals("foo", line.getOptionValue('a'), "flag a");
+        assertEquals("foo", line.getOptionObject('a'), "string flag a");
+        assertEquals(new Vector<>(), line.getOptionObject('b'), "object flag b");
+        assertTrue(line.hasOption('c'), "boolean true flag c");
+        assertFalse(line.hasOption('d'), "boolean false flag d");
+        assertEquals(new File("build.xml"), line.getOptionObject('e'), "file flag e");
+        assertEquals(Calendar.class, line.getOptionObject('f'), "class flag f");
+        assertEquals(Double.valueOf(4.5), line.getOptionObject('n'), "number flag n");
+        assertEquals(new URL("https://commons.apache.org"), line.getOptionObject('t'), "url flag t");
 
         // FILES NOT SUPPORTED YET
         try {
-            assertEquals("files flag m", new File[0], line.getOptionObject('m'));
+            assertEquals(new File[0], line.getOptionObject('m'), "files flag m");
             fail("Multiple files are not supported yet, should have failed");
         } catch (final UnsupportedOperationException uoe) {
             // expected
         }
 
-        assertEquals("date flag z", new Date(1023400137000L), line.getOptionObject('z'));
+        assertEquals(new Date(1023400137000L), line.getOptionObject('z'), "date flag z");
 
     }
 
@@ -172,11 +172,11 @@ public class PatternOptionBuilderTest {
         final CommandLine line = parser.parse(options, new String[] {"-abc"});
 
         assertTrue(line.hasOption('a'));
-        assertNull("value a", line.getOptionObject('a'));
+        assertNull(line.getOptionObject('a'), "value a");
         assertTrue(line.hasOption('b'));
-        assertNull("value b", line.getOptionObject('b'));
+        assertNull(line.getOptionObject('b'), "value b");
         assertTrue(line.hasOption('c'));
-        assertNull("value c", line.getOptionObject('c'));
+        assertNull(line.getOptionObject('c'), "value c");
     }
 
     @Test
@@ -185,7 +185,7 @@ public class PatternOptionBuilderTest {
         final CommandLineParser parser = new PosixParser();
         final CommandLine line = parser.parse(options, new String[] {"-u", "https://commons.apache.org", "-v", "foo://commons.apache.org"});
 
-        assertEquals("u value", new URL("https://commons.apache.org"), line.getOptionObject("u"));
-        assertNull("v value", line.getOptionObject("v"));
+        assertEquals(new URL("https://commons.apache.org"), line.getOptionObject("u"), "u value");
+        assertNull(line.getOptionObject("v"), "v value");
     }
 }

--- a/src/test/java/org/apache/commons/cli/PosixParserTest.java
+++ b/src/test/java/org/apache/commons/cli/PosixParserTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.cli;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for the PosixParser.
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class PosixParserTest extends AbstractParserTestCase {
     @Override
     @SuppressWarnings("deprecation")
-    @Before
+    @BeforeEach
     public void setUp() {
         super.setUp();
         parser = new PosixParser();
@@ -35,61 +35,61 @@ public class PosixParserTest extends AbstractParserTestCase {
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testAmbiguousLongWithoutEqualSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testAmbiguousLongWithoutEqualSingleDash2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testAmbiguousPartialLongOption4() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testDoubleDash2() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testLongWithEqualSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testLongWithoutEqualSingleDash() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testLongWithUnexpectedArgument1() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser (CLI-184)")
+    @Disabled("not supported by the PosixParser (CLI-184)")
     public void testNegativeOption() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testShortWithEqual() throws Exception {
     }
 
     @Override
     @Test
-    @Ignore("not supported by the PosixParser")
+    @Disabled("not supported by the PosixParser")
     public void testUnambiguousPartialLongOption4() throws Exception {
     }
 }

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;

--- a/src/test/java/org/apache/commons/cli/UtilTest.java
+++ b/src/test/java/org/apache/commons/cli/UtilTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilTest {
     @Test

--- a/src/test/java/org/apache/commons/cli/ValueTest.java
+++ b/src/test/java/org/apache/commons/cli/ValueTest.java
@@ -17,20 +17,20 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class ValueTest {
     private CommandLine cl;
     private final Options opts = new Options();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         opts.addOption("a", false, "toggle -a");
         opts.addOption("b", true, "set -b");

--- a/src/test/java/org/apache/commons/cli/ValuesTest.java
+++ b/src/test/java/org/apache/commons/cli/ValuesTest.java
@@ -17,19 +17,19 @@
 
 package org.apache.commons.cli;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class ValuesTest {
     private CommandLine cmd;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final Options options = new Options();
 
@@ -75,44 +75,44 @@ public class ValuesTest {
     @Test
     public void testCharSeparator() {
         // tests the char methods of CommandLine that delegate to the String methods
-        assertTrue("Option j is not set", cmd.hasOption("j"));
-        assertTrue("Option j is not set", cmd.hasOption('j'));
+        assertTrue(cmd.hasOption("j"), "Option j is not set");
+        assertTrue(cmd.hasOption('j'), "Option j is not set");
         assertArrayEquals(new String[] {"key", "value", "key", "value"}, cmd.getOptionValues("j"));
         assertArrayEquals(new String[] {"key", "value", "key", "value"}, cmd.getOptionValues('j'));
 
-        assertTrue("Option k is not set", cmd.hasOption("k"));
-        assertTrue("Option k is not set", cmd.hasOption('k'));
+        assertTrue(cmd.hasOption("k"), "Option k is not set");
+        assertTrue(cmd.hasOption('k'), "Option k is not set");
         assertArrayEquals(new String[] {"key1", "value1", "key2", "value2"}, cmd.getOptionValues("k"));
         assertArrayEquals(new String[] {"key1", "value1", "key2", "value2"}, cmd.getOptionValues('k'));
 
-        assertTrue("Option m is not set", cmd.hasOption("m"));
-        assertTrue("Option m is not set", cmd.hasOption('m'));
+        assertTrue(cmd.hasOption("m"), "Option m is not set");
+        assertTrue(cmd.hasOption('m'), "Option m is not set");
         assertArrayEquals(new String[] {"key", "value"}, cmd.getOptionValues("m"));
         assertArrayEquals(new String[] {"key", "value"}, cmd.getOptionValues('m'));
     }
 
     @Test
     public void testComplexValues() {
-        assertTrue("Option i is not set", cmd.hasOption("i"));
-        assertTrue("Option h is not set", cmd.hasOption("h"));
+        assertTrue(cmd.hasOption("i"), "Option i is not set");
+        assertTrue(cmd.hasOption("h"), "Option h is not set");
         assertArrayEquals(new String[] {"val1", "val2"}, cmd.getOptionValues("h"));
     }
 
     @Test
     public void testExtraArgs() {
-        assertArrayEquals("Extra args", new String[] {"arg1", "arg2", "arg3"}, cmd.getArgs());
+        assertArrayEquals(new String[] {"arg1", "arg2", "arg3"}, cmd.getArgs(), "Extra args");
     }
 
     @Test
     public void testMultipleArgValues() {
-        assertTrue("Option e is not set", cmd.hasOption("e"));
+        assertTrue(cmd.hasOption("e"), "Option e is not set");
         assertArrayEquals(new String[] {"one", "two"}, cmd.getOptionValues("e"));
     }
 
     @Test
     public void testShortArgs() {
-        assertTrue("Option a is not set", cmd.hasOption("a"));
-        assertTrue("Option c is not set", cmd.hasOption("c"));
+        assertTrue(cmd.hasOption("a"), "Option a is not set");
+        assertTrue(cmd.hasOption("c"), "Option c is not set");
 
         assertNull(cmd.getOptionValues("a"));
         assertNull(cmd.getOptionValues("c"));
@@ -120,18 +120,18 @@ public class ValuesTest {
 
     @Test
     public void testShortArgsWithValue() {
-        assertTrue("Option b is not set", cmd.hasOption("b"));
+        assertTrue(cmd.hasOption("b"), "Option b is not set");
         assertEquals("foo", cmd.getOptionValue("b"));
         assertEquals(1, cmd.getOptionValues("b").length);
 
-        assertTrue("Option d is not set", cmd.hasOption("d"));
+        assertTrue(cmd.hasOption("b"), "Option b is not set");
         assertEquals("bar", cmd.getOptionValue("d"));
         assertEquals(1, cmd.getOptionValues("d").length);
     }
 
     @Test
     public void testTwoArgValues() {
-        assertTrue("Option g is not set", cmd.hasOption("g"));
+        assertTrue(cmd.hasOption("g"), "Option g is not set");
         assertArrayEquals(new String[] {"val1", "val2"}, cmd.getOptionValues("g"));
     }
 

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI133Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI133Test.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class BugCLI133Test {

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI13Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI13Test.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -26,7 +26,7 @@ import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class BugCLI13Test {

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI148Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI148Test.java
@@ -17,15 +17,15 @@
 
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * https://issues.apache.org/jira/browse/CLI-148
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class BugCLI148Test {
     private Options options;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         options = new Options();
         options.addOption(OptionBuilder.hasArg().create('t'));

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI162Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI162Test.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -28,8 +28,8 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BugCLI162Test {
     /** Constant for the line separator. */
@@ -108,7 +108,7 @@ public class BugCLI162Test {
 
     private StringWriter sw;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         formatter = new HelpFormatter();
         sw = new StringWriter();
@@ -165,7 +165,7 @@ public class BugCLI162Test {
                           "                      yes." + CR +
                           "Footer" + CR;
         //@formatter:on
-        assertEquals("Long arguments did not split as expected", expected, sw.toString());
+        assertEquals(expected, sw.toString(), "Long arguments did not split as expected");
     }
 
     @Test
@@ -184,7 +184,7 @@ public class BugCLI162Test {
                           " Long." + CR +
                           "Footer" + CR;
         //@formatter:on
-        assertEquals("Long arguments did not split as expected", expected, sw.toString());
+        assertEquals(expected, sw.toString(), "Long arguments did not split as expected");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI18Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI18Test.java
@@ -23,7 +23,7 @@ import java.io.StringWriter;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * https://issues.apache.org/jira/browse/CLI-18

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI252Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI252Test.java
@@ -24,7 +24,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BugCLI252Test {
 

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI265Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI265Test.java
@@ -17,18 +17,18 @@
 
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for CLI-265.
@@ -40,7 +40,7 @@ public class BugCLI265Test {
     private DefaultParser parser;
     private Options options;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         parser = new DefaultParser();
 
@@ -72,8 +72,8 @@ public class BugCLI265Test {
         final CommandLine commandLine = parser.parse(options, twoShortOptions);
 
         assertTrue(commandLine.hasOption("t1"));
-        assertNotEquals("Second option has been used as value for first option", "-last", commandLine.getOptionValue("t1"));
-        assertTrue("Second option has not been detected", commandLine.hasOption("last"));
+        assertNotEquals(commandLine.getOptionValue("t1"), "Second option has been used as value for first option", "-last");
+        assertTrue(commandLine.hasOption("last"), "Second option has not been detected");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI266Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI266Test.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.cli.bug;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,8 +29,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BugCLI266Test {
 
@@ -110,7 +111,7 @@ public class BugCLI266Test {
         Collections.sort(options, formatter.getOptionComparator());
         int i = 0;
         for (final Option o : options) {
-            Assert.assertEquals(o.getOpt(), sortOrder.get(i));
+            assertEquals(o.getOpt(), sortOrder.get(i));
             i++;
         }
     }
@@ -120,7 +121,7 @@ public class BugCLI266Test {
         final Collection<Option> options = getOptions().getOptions();
         int i = 0;
         for (final Option o : options) {
-            Assert.assertEquals(o.getOpt(), insertedOrder.get(i));
+            assertEquals(o.getOpt(), insertedOrder.get(i));
             i++;
         }
     }

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI312Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI312Test.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Properties;
@@ -30,7 +30,7 @@ import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Demonstrates inconsistencies in parsing Java property-style options.

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI325Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI325Test.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Properties;
 
@@ -26,7 +26,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BugCLI325Test {
 

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI71Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI71Test.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -26,15 +26,15 @@ import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class BugCLI71Test {
     private Options options;
     private CommandLineParser parser;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         options = new Options();
 
@@ -74,7 +74,7 @@ public class BugCLI71Test {
             parser.parse(options, args);
             fail("MissingArgumentException expected");
         } catch (final MissingArgumentException e) {
-            assertEquals("option missing an argument", "k", e.getOption().getOpt());
+            assertEquals("k", e.getOption().getOpt(), "option missing an argument");
         }
     }
 

--- a/src/test/java/org/apache/commons/cli/bug/BugsTest.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugsTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.cli.bug;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -41,7 +41,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.Parser;
 import org.apache.commons.cli.PosixParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class BugsTest {


### PR DESCRIPTION
This removes references to JUnit 4 test constructions and switches all tests to JUnit 5.

Unfortunately, JUnit 5's assertions have swapped the optional "message" argument from first to last, this makes the diff bigger than it would have otherwise been.