### PR TITLE
[CLI-327] Fix for expected textual date values.

### DIFF
--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -77,6 +77,12 @@ public class ConverterTests {
     public void dateTests() throws Exception {
         assertThrows(java.text.ParseException.class, () -> Converter.DATE.apply("whatever"));
 
+        /*
+         * Dates calculated from strings are dependent upon configuration and environment settings for the
+         * machine on which the test is running.  To avoid this problem, convert the time into a string
+         * and then unparse that using the converter.  This produces strings that always match the correct
+         * time zone.
+         */
         final Date expected = new Date(1023400137000L);
         DateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
         String formatted = dateFormat.format(expected);

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URL;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -75,8 +77,10 @@ public class ConverterTests {
     public void dateTests() throws Exception {
         assertThrows(java.text.ParseException.class, () -> Converter.DATE.apply("whatever"));
 
-        final Date d = new Date(1023400137000L);
-        assertEquals(d, Converter.DATE.apply("Thu Jun 06 17:48:57 EDT 2002"));
+        final Date expected = new Date(1023400137000L);
+        DateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
+        String formatted = dateFormat.format(expected);
+        assertEquals(expected, Converter.DATE.apply(formatted));
 
         assertThrows(java.text.ParseException.class, () -> Converter.DATE.apply("Jun 06 17:48:57 EDT 2002"));
     }

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -27,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Vector;
@@ -126,8 +128,10 @@ public class PatternOptionBuilderTest {
     @Test
     public void testSimplePattern() throws Exception {
         final Options options = PatternOptionBuilder.parsePattern("a:b@cde>f+n%t/m*z#");
+        final Date expectedDate = new Date(1023400137000L);
+        DateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
         final String[] args = {"-c", "-a", "foo", "-b", "java.util.Vector", "-e", "build.xml", "-f", "java.util.Calendar", "-n", "4.5", "-t",
-            "https://commons.apache.org", "-z", "Thu Jun 06 17:48:57 EDT 2002", "-m", "test*"};
+            "https://commons.apache.org", "-z", dateFormat.format(expectedDate), "-m", "test*"};
 
         final CommandLineParser parser = new PosixParser();
         final CommandLine line = parser.parse(options, args);
@@ -161,7 +165,7 @@ public class PatternOptionBuilderTest {
             // expected
         }
 
-        assertEquals(new Date(1023400137000L), line.getOptionObject('z'), "date flag z");
+        assertEquals(expectedDate, line.getOptionObject('z'), "date flag z");
 
     }
 

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -127,6 +127,12 @@ public class PatternOptionBuilderTest {
 
     @Test
     public void testSimplePattern() throws Exception {
+        /*
+         * Dates calculated from strings are dependent upon configuration and environment settings for the
+         * machine on which the test is running.  To avoid this problem, convert the time into a string
+         * and then unparse that using the converter.  This produces strings that always match the correct
+         * time zone.
+         */
         final Options options = PatternOptionBuilder.parsePattern("a:b@cde>f+n%t/m*z#");
         final Date expectedDate = new Date(1023400137000L);
         DateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -70,6 +70,12 @@ public class TypeHandlerTest {
         TypeHandler.resetConverters();
         final List<Arguments> lst = new ArrayList<>();
 
+        /*
+         * Dates calculated from strings are dependent upon configuration and environment settings for the
+         * machine on which the test is running.  To avoid this problem, convert the time into a string
+         * and then unparse that using the converter.  This produces strings that always match the correct
+         * time zone.
+         */
         final Date date = new Date(1023400137000L);
         final DateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
 

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -28,6 +28,8 @@ import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -62,19 +64,21 @@ public class TypeHandlerTest {
     }
 
     private static Stream<Arguments> createValueTestParameters() {
-        // forse the PatternOptionBuilder to load / modify the TypeHandler table.
+        // force the PatternOptionBuilder to load / modify the TypeHandler table.
         final Class<?> ignore = PatternOptionBuilder.FILES_VALUE;
         // reset the type handler table.
         TypeHandler.resetConverters();
         final List<Arguments> lst = new ArrayList<>();
+
+        final Date date = new Date(1023400137000L);
+        final DateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy");
 
         try {
             lst.add(Arguments.of(Instantiable.class.getName(), PatternOptionBuilder.CLASS_VALUE, Instantiable.class));
             lst.add(Arguments.of("what ever", PatternOptionBuilder.CLASS_VALUE, ParseException.class));
 
             lst.add(Arguments.of("what ever", PatternOptionBuilder.DATE_VALUE, ParseException.class));
-            lst.add(Arguments.of("Thu Jun 06 17:48:57 EDT 2002", PatternOptionBuilder.DATE_VALUE,
-                    new Date(1023400137000L)));
+            lst.add(Arguments.of(dateFormat.format(date), PatternOptionBuilder.DATE_VALUE, date));
             lst.add(Arguments.of("Jun 06 17:48:57 EDT 2002", PatternOptionBuilder.DATE_VALUE, ParseException.class));
 
             lst.add(Arguments.of("non-existing.file", PatternOptionBuilder.EXISTING_FILE_VALUE, ParseException.class));


### PR DESCRIPTION
Fixes for CLI-327

In some cases the time zone for the expected date string is different than the hard coded version.  This change creates the expected value from a known simple date format of the Date argument so that the expected value always matches the produced time zone.