### PR TITLE
CLI-329: introduce to Options the tracking of deprecated short and long opts

### DIFF
--- a/src/main/java/org/apache/commons/cli/CommandLine.java
+++ b/src/main/java/org/apache/commons/cli/CommandLine.java
@@ -599,11 +599,11 @@ public class CommandLine implements Serializable {
                 if (actual.equals(option.getOpt()) || actual.equals(option.getLongOpt())) {
                     return option;
                 }
-                else if (actual.equals(option.getDeprecatedOpt() )) {
+                else if (actual.equals(option.getDeprecatedOpt())) {
                     System.out.println("Using deprecated option name '" + actual + "' instead of proper name '" + option.getOpt() + "'");
                     return option;
                 }
-                else if (actual.equals(option.getDeprecatedLongOpt() )) {
+                else if (actual.equals(option.getDeprecatedLongOpt())) {
                     System.out.println("Using deprecated long option '" + actual + "' instead of proper long name '" + option.getLongOpt() + "'");
                     return option;
                 }

--- a/src/main/java/org/apache/commons/cli/CommandLine.java
+++ b/src/main/java/org/apache/commons/cli/CommandLine.java
@@ -587,6 +587,7 @@ public class CommandLine implements Serializable {
 
     /**
      * Retrieves the option object given the long or short option as a String
+     * It also consults any deprecated option names.
      *
      * @param opt short or long name of the option, may be null.
      * @return Canonicalized option.
@@ -596,6 +597,14 @@ public class CommandLine implements Serializable {
         if (actual != null) {
             for (final Option option : options) {
                 if (actual.equals(option.getOpt()) || actual.equals(option.getLongOpt())) {
+                    return option;
+                }
+                else if (actual.equals(option.getDeprecatedOpt() )) {
+                    System.out.println("Using deprecated option name '" + actual + "' instead of proper name '" + option.getOpt() + "'");
+                    return option;
+                }
+                else if (actual.equals(option.getDeprecatedLongOpt() )) {
+                    System.out.println("Using deprecated long option '" + actual + "' instead of proper long name '" + option.getLongOpt() + "'");
                     return option;
                 }
             }

--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -42,6 +42,7 @@ import java.util.Objects;
  */
 public class Option implements Cloneable, Serializable {
 
+
     /**
      * Builds {@code Option} instances using descriptive methods.
      * <p>
@@ -64,6 +65,12 @@ public class Option implements Cloneable, Serializable {
 
         /** The long representation of the option. */
         private String longOption;
+
+        /** Specifies if the option had a previous deprecated long representation of the option. */
+        private String deprecatedLongOption;
+
+        /** Specifies if the option had a previous deprecated representation of the option. */
+        private String deprecatedOption;
 
         /** The name of the argument for this option. */
         private String argName;
@@ -186,6 +193,29 @@ public class Option implements Cloneable, Serializable {
             this.longOption = longOpt;
             return this;
         }
+
+        /**
+         * Sets the deprecated long name of the Option.
+         *
+         * @param deprecatedLongOption the deprecated long name of the Option
+         * @return this builder.
+         */
+        public Builder deprecatedLongOption(final String deprecatedLongOption) {
+            this.deprecatedLongOption = deprecatedLongOption;
+            return this;
+        }
+        /**
+         * Sets the deprecated long name of the Option.
+         *
+         * @param deprecatedOption the deprecated name of the Option
+         * @return this builder.
+         */
+        public Builder deprecatedOption(final String deprecatedOption) {
+            this.deprecatedOption = deprecatedOption;
+            return this;
+        }
+
+
 
         /**
          * Sets the number of argument values the Option can take.
@@ -332,6 +362,12 @@ public class Option implements Cloneable, Serializable {
     /** The long representation of the option. */
     private String longOption;
 
+    /** Deprecated Long option */
+    private String deprecatedLongOption;
+
+    /** Deprecated option */
+    private String deprecatedOption;
+
     /** The name of the argument for this option. */
     private String argName;
 
@@ -368,6 +404,8 @@ public class Option implements Cloneable, Serializable {
         this.argName = builder.argName;
         this.description = builder.description;
         this.longOption = builder.longOption;
+        this.deprecatedLongOption = builder.deprecatedLongOption;
+        this.deprecatedOption = builder.deprecatedOption;
         this.argCount = builder.argCount;
         this.option = builder.option;
         this.optionalArg = builder.optionalArg;
@@ -608,6 +646,14 @@ public class Option implements Cloneable, Serializable {
         return option;
     }
 
+    public String getDeprecatedLongOpt() {
+        return deprecatedLongOption;
+    }
+
+    public String getDeprecatedOpt() {
+        return deprecatedOption;
+    }
+
     /**
      * Gets the type of this Option.
      *
@@ -718,6 +764,24 @@ public class Option implements Cloneable, Serializable {
      */
     public boolean hasLongOpt() {
         return longOption != null;
+    }
+
+    /**
+     * Tests whether this Option has a deprecated long name.
+     *
+     * @return boolean flag indicating existence of a deprecated long name.
+     */
+    public boolean hasDeprecatedLongOpt() {
+        return deprecatedLongOption != null;
+    }
+
+    /**
+     * Tests whether this Option has a deprecated option name.
+     *
+     * @return boolean flag indicating existence of a deprecated option name.
+     */
+    public boolean hasDeprecatedOption() {
+        return deprecatedOption != null;
     }
 
     /**
@@ -859,6 +923,24 @@ public class Option implements Cloneable, Serializable {
      */
     public void setLongOpt(final String longOpt) {
         this.longOption = longOpt;
+    }
+
+    /**
+     * Sets the deprecated long name of this Option.
+     *
+     * @param deprecatedLongOption the deprecated long name of this Option.
+     */
+    public void setDeprecatedLongOption(final String deprecatedLongOption) {
+        this.deprecatedLongOption = deprecatedLongOption;
+    }
+
+    /**
+     * Sets the deprecated ame of this Option.
+     *
+     * @param deprecatedOption the deprecated name of this Option.
+     */
+    public void setDeprecatedOption(final String deprecatedOption) {
+        this.deprecatedOption = deprecatedOption;
     }
 
     /**

--- a/src/main/java/org/apache/commons/cli/OptionBuilder.java
+++ b/src/main/java/org/apache/commons/cli/OptionBuilder.java
@@ -35,6 +35,12 @@ public final class OptionBuilder {
     /** Long option */
     private static String longOption;
 
+    /** Deprecated Long option */
+    private static String deprecatedLongOption;
+
+    /** Deprecated option */
+    private static String deprecatedOption;
+
     /** Option description */
     private static String description;
 
@@ -104,9 +110,11 @@ public final class OptionBuilder {
             option = new Option(opt, description);
 
             // set the option properties
-            option.setLongOpt(longOption);
             option.setRequired(required);
+            option.setLongOpt(longOption);
             option.setOptionalArg(optionalArg);
+            option.setDeprecatedOption(deprecatedOption);
+            option.setDeprecatedLongOption(deprecatedLongOption);
             option.setArgs(argCount);
             option.setType(type);
             option.setConverter(TypeHandler.getConverter(type));
@@ -234,6 +242,8 @@ public final class OptionBuilder {
         description = null;
         argName = null;
         longOption = null;
+        deprecatedOption = null;
+        deprecatedLongOption = null;
         type = String.class;
         required = false;
         argCount = Option.UNINITIALIZED;
@@ -350,10 +360,22 @@ public final class OptionBuilder {
         return INSTANCE;
     }
 
+    public static OptionBuilder withDeprecatedLongOpt(String deprecatedLongOption) {
+        OptionBuilder.deprecatedLongOption = deprecatedLongOption;
+
+        return INSTANCE;
+    }
+
+    public static OptionBuilder withDeprecatedOpt(String deprecatedOption){
+        OptionBuilder.deprecatedOption = deprecatedOption;
+
+        return INSTANCE;
+    }
     /**
      * private constructor to prevent instances being created
      */
     private OptionBuilder() {
         // hide the constructor
     }
+
 }

--- a/src/main/java/org/apache/commons/cli/OptionBuilder.java
+++ b/src/main/java/org/apache/commons/cli/OptionBuilder.java
@@ -360,13 +360,13 @@ public final class OptionBuilder {
         return INSTANCE;
     }
 
-    public static OptionBuilder withDeprecatedLongOpt(String deprecatedLongOption) {
+    public static OptionBuilder withDeprecatedLongOpt(final String deprecatedLongOption) {
         OptionBuilder.deprecatedLongOption = deprecatedLongOption;
 
         return INSTANCE;
     }
 
-    public static OptionBuilder withDeprecatedOpt(String deprecatedOption){
+    public static OptionBuilder withDeprecatedOpt(final String deprecatedOption) {
         OptionBuilder.deprecatedOption = deprecatedOption;
 
         return INSTANCE;

--- a/src/main/java/org/apache/commons/cli/Options.java
+++ b/src/main/java/org/apache/commons/cli/Options.java
@@ -66,6 +66,9 @@ public class Options implements Serializable {
         if (opt.hasLongOpt()) {
             longOpts.put(opt.getLongOpt(), opt);
         }
+        if (opt.hasDeprecatedLongOpt()) {
+            longOpts.put(opt.getDeprecatedLongOpt(), opt);
+        }
         // if the option is required add it to the required list
         if (opt.isRequired()) {
             if (requiredOpts.contains(key)) {
@@ -74,6 +77,9 @@ public class Options implements Serializable {
             requiredOpts.add(key);
         }
         shortOpts.put(key, opt);
+        if (opt.hasDeprecatedOption()) {
+            shortOpts.put(opt.getDeprecatedOpt(), opt);
+        }
         return this;
     }
 

--- a/src/test/java/org/apache/commons/cli/DefaultParserTest.java
+++ b/src/test/java/org/apache/commons/cli/DefaultParserTest.java
@@ -120,4 +120,25 @@ public class DefaultParserTest extends AbstractParserTestCase {
 
         assertEquals("quoted string", cl.getOptionValue("b"), "Confirm -b \"arg\" strips quotes");
     }
+
+    @Test
+    public void testUsingDeprecatedOptions() throws Exception {
+
+        options = new Options().addOption(
+                Option.builder("a")
+                        .longOpt("enable-a")
+                        .hasArg(true)
+                        .deprecatedLongOption("old-enable-a")
+                        .deprecatedOption("z").build());
+
+        parser = DefaultParser.builder().build();
+
+        final String[] args = {"-a", "arg"};
+        final CommandLine cl = parser.parse(options, args);
+
+        assertEquals("arg", cl.getOptionValue("a"), "normal name look up");
+        assertEquals("arg", cl.getOptionValue("enable-a"), "normal long name look up");
+        assertEquals("arg", cl.getOptionValue("z"), "deprecated name look up");
+        assertEquals("arg", cl.getOptionValue("old-enable-a"), "deprecated long name look up");
+    }
 }

--- a/src/test/java/org/apache/commons/cli/OptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionBuilderTest.java
@@ -158,6 +158,8 @@ public class OptionBuilderTest {
     public void testTwoCompleteOptions() {
         //@formatter:off
         Option simple = OptionBuilder.withLongOpt("simple option")
+                                     .withDeprecatedLongOpt("deprecated simple option")
+                                     .withDeprecatedOpt("deprecated-s")
                                      .hasArg()
                                      .isRequired()
                                      .hasArgs()
@@ -168,6 +170,8 @@ public class OptionBuilderTest {
 
         assertEquals("s", simple.getOpt());
         assertEquals("simple option", simple.getLongOpt());
+        assertEquals("deprecated-s", simple.getDeprecatedOpt());
+        assertEquals("deprecated simple option", simple.getDeprecatedLongOpt());
         assertEquals("this is a simple option", simple.getDescription());
         assertEquals(simple.getType(), Float.class);
         assertTrue(simple.hasArg());


### PR DESCRIPTION
This allows you to migrate from a previous old short options to new ones.

In the Apache Solr project we would use it to support the migration of `-zkHost` to `--zk-host` for example by allowing the deprecated command line `-zkHost` to function, but logging an warning to the user with the preferred option name.  