### PR TITLE
[CLI-332] Add optional HelpFormatter Function to document Deprecated options

### DIFF
--- a/src/main/java/org/apache/commons/cli/HelpFormatter.java
+++ b/src/main/java/org/apache/commons/cli/HelpFormatter.java
@@ -30,7 +30,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -76,12 +75,15 @@ public class HelpFormatter {
         // TODO All other instance HelpFormatter instance variables.
         // Make HelpFormatter immutable for 2.0
 
-        private static final BiFunction<String, Option,String> DEFAULT_DEPRECATED_FORMAT = (d,o) -> "[Deprecated] "+d;
+        /**
+         * A function to convert a description (not null) and a deprecated Option (not null) to help description
+         */
+        private static final BiFunction<String, Option, String> DEFAULT_DEPRECATED_FORMAT = (d, o) -> "[Deprecated] " + d;
 
         /**
          * Formatter for deprecated options.
          */
-        private BiFunction<String,Option,String> deprecatedFormatFunc;
+        private BiFunction<String, Option, String> deprecatedFormatFunc;
 
         /**
          * The output PrintWriter, defaults to wrapping {@link System#out}.
@@ -120,7 +122,7 @@ public class HelpFormatter {
          * @param showDeprecatedFunc Specify the format for the deprecated options.
          * @return this.
          */
-        public Builder setShowDeprecated(final BiFunction<String,Option,String> showDeprecatedFunc) {
+        public Builder setShowDeprecated(final BiFunction<String, Option, String> showDeprecatedFunc) {
             this.deprecatedFormatFunc = showDeprecatedFunc;
             return this;
         }
@@ -265,7 +267,7 @@ public class HelpFormatter {
     /**
      * BiFunction to format the description for a deprecated option.
      */
-    private final BiFunction<String,Option,String> deprecatedFormatFunc;
+    private final BiFunction<String, Option, String> deprecatedFormatFunc;
 
     /**
      * Where to print help.
@@ -288,7 +290,7 @@ public class HelpFormatter {
      * Constructs a new instance.
      * @param printStream TODO
      */
-    private HelpFormatter(final BiFunction<String, Option,String> deprecatedFormatFunc, final PrintWriter printStream) {
+    private HelpFormatter(final BiFunction<String, Option, String> deprecatedFormatFunc, final PrintWriter printStream) {
         // TODO All other instance HelpFormatter instance variables.
         // Make HelpFormatter immutable for 2.0
         this.deprecatedFormatFunc = deprecatedFormatFunc;
@@ -792,7 +794,7 @@ public class HelpFormatter {
             optBuf.append(dpad);
             final int nextLineTabStop = max + descPad;
             if (deprecatedFormatFunc != null && option.isDeprecated()) {
-                optBuf.append(deprecatedFormatFunc.apply(option.getDescription()==null?"":option.getDescription(), option).trim());
+                optBuf.append(deprecatedFormatFunc.apply(option.getDescription() == null ? "" : option.getDescription(), option).trim());
             } else if (option.getDescription() != null) {
                 optBuf.append(option.getDescription());
             }

--- a/src/main/java/org/apache/commons/cli/HelpFormatter.java
+++ b/src/main/java/org/apache/commons/cli/HelpFormatter.java
@@ -121,6 +121,7 @@ public class HelpFormatter {
          *
          * @param showDeprecatedFunc Specify the format for the deprecated options.
          * @return this.
+         * @since(1.8.0)
          */
         public Builder setShowDeprecated(final BiFunction<String, Option, String> showDeprecatedFunc) {
             this.deprecatedFormatFunc = showDeprecatedFunc;

--- a/src/main/java/org/apache/commons/cli/HelpFormatter.java
+++ b/src/main/java/org/apache/commons/cli/HelpFormatter.java
@@ -121,7 +121,7 @@ public class HelpFormatter {
          *
          * @param showDeprecatedFunc Specify the format for the deprecated options.
          * @return this.
-         * @since(1.8.0)
+         * @since 1.8.0
          */
         public Builder setShowDeprecated(final BiFunction<String, Option, String> showDeprecatedFunc) {
             this.deprecatedFormatFunc = showDeprecatedFunc;

--- a/src/test/java/org/apache/commons/cli/HelpFormatterTest.java
+++ b/src/test/java/org/apache/commons/cli/HelpFormatterTest.java
@@ -492,7 +492,7 @@ public class HelpFormatterTest {
 
     @ParameterizedTest
     @MethodSource("deprecatedOptionsProvider")
-    public void testPrintDeprecatedOptions(HelpFormatter hf, Option option, String expectedTxt) {
+    public void testPrintDeprecatedOptions(final HelpFormatter hf, final Option option, final String expectedTxt) {
         final StringBuffer sb = new StringBuffer();
 
         final int leftPad = 1;
@@ -500,7 +500,7 @@ public class HelpFormatterTest {
         final String lpad = hf.createPadding(leftPad);
         final String dpad = hf.createPadding(descPad);
         Options options;
-        String expected = expected = lpad + "-a,--aaa";
+        String expected = lpad + "-a,--aaa";
 
         options = new Options().addOption(option);
         if (expectedTxt.length() > 0) {
@@ -523,7 +523,7 @@ public class HelpFormatterTest {
         hf = HelpFormatter.builder().setShowDeprecated(true).get();
         lst.add(Arguments.of(hf, option, "[Deprecated] dddd dddd dddd"));
 
-        hf = HelpFormatter.builder().setShowDeprecated((d,o) -> String.format("%s [%s]",d,o.getDeprecated())).get();
+        hf = HelpFormatter.builder().setShowDeprecated((d, o) -> String.format("%s [%s]", d, o.getDeprecated())).get();
         lst.add(Arguments.of(hf, option, "dddd dddd dddd [Deprecated for removal since now: Why why why]"));
 
         option = Option.builder("a").longOpt("aaa")
@@ -537,7 +537,7 @@ public class HelpFormatterTest {
         hf = HelpFormatter.builder().setShowDeprecated(true).get();
         lst.add(Arguments.of(hf, option, "[Deprecated]"));
 
-        hf = HelpFormatter.builder().setShowDeprecated((d,o)-> String.format("%s [%s]",d,o.getDeprecated())).get();
+        hf = HelpFormatter.builder().setShowDeprecated((d, o) -> String.format("%s [%s]", d, o.getDeprecated())).get();
         lst.add(Arguments.of(hf, option, "[Deprecated for removal since now: Why why why]"));
 
         return lst.stream();

--- a/src/test/java/org/apache/commons/cli/HelpFormatterTest.java
+++ b/src/test/java/org/apache/commons/cli/HelpFormatterTest.java
@@ -24,9 +24,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.commons.cli.HelpFormatter.Builder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test case for the HelpFormatter class.
@@ -482,6 +488,59 @@ public class HelpFormatterTest {
         sb.setLength(0);
         hf.renderOptions(sb, 25, options, leftPad, descPad);
         assertEquals(expected, sb.toString(), "multiple wrapped options");
+    }
+
+    @ParameterizedTest
+    @MethodSource("deprecatedOptionsProvider")
+    public void testPrintDeprecatedOptions(HelpFormatter hf, Option option, String expectedTxt) {
+        final StringBuffer sb = new StringBuffer();
+
+        final int leftPad = 1;
+        final int descPad = 3;
+        final String lpad = hf.createPadding(leftPad);
+        final String dpad = hf.createPadding(descPad);
+        Options options;
+        String expected = expected = lpad + "-a,--aaa";
+
+        options = new Options().addOption(option);
+        if (expectedTxt.length() > 0) {
+            expected = expected + dpad + expectedTxt;
+        }
+        hf.renderOptions(sb, 160, options, leftPad, descPad);
+        assertEquals(expected, sb.toString());
+    }
+
+    static Stream<Arguments> deprecatedOptionsProvider() {
+        List<Arguments> lst = new ArrayList<>();
+        Option option = Option.builder("a").longOpt("aaa").desc("dddd dddd dddd")
+                .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("now")
+                        .setDescription("Why why why").get())
+                .build();
+
+        HelpFormatter hf = HelpFormatter.builder().setShowDeprecated(false).get();
+        lst.add(Arguments.of(hf, option, "dddd dddd dddd"));
+
+        hf = HelpFormatter.builder().setShowDeprecated(true).get();
+        lst.add(Arguments.of(hf, option, "[Deprecated] dddd dddd dddd"));
+
+        hf = HelpFormatter.builder().setShowDeprecated((d,o) -> String.format("%s [%s]",d,o.getDeprecated())).get();
+        lst.add(Arguments.of(hf, option, "dddd dddd dddd [Deprecated for removal since now: Why why why]"));
+
+        option = Option.builder("a").longOpt("aaa")
+                .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("now")
+                        .setDescription("Why why why").get())
+                .build();
+
+        hf = HelpFormatter.builder().setShowDeprecated(false).get();
+        lst.add(Arguments.of(hf, option, ""));
+
+        hf = HelpFormatter.builder().setShowDeprecated(true).get();
+        lst.add(Arguments.of(hf, option, "[Deprecated]"));
+
+        hf = HelpFormatter.builder().setShowDeprecated((d,o)-> String.format("%s [%s]",d,o.getDeprecated())).get();
+        lst.add(Arguments.of(hf, option, "[Deprecated for removal since now: Why why why]"));
+
+        return lst.stream();
     }
 
     @Test


### PR DESCRIPTION
Implement new feature [CLI-332](https://issues.apache.org/jira/browse/CLI-332)

Added a `BiFunction<String, Object, String>` to the HelpFormatter and its Builder.    Also tests for same.