### PR TITLE
[CLI-336] Deprecation not always reported

### DIFF
--- a/src/main/java/org/apache/commons/cli/CommandLine.java
+++ b/src/main/java/org/apache/commons/cli/CommandLine.java
@@ -441,12 +441,12 @@ public class CommandLine implements Serializable {
         if (option == null) {
             return null;
         }
-        if (option.isDeprecated()) {
-            handleDeprecated(option);
-        }
         final List<String> values = new ArrayList<>();
         for (final Option processedOption : options) {
             if (processedOption.equals(option)) {
+                if (option.isDeprecated()) {
+                    handleDeprecated(option);
+                }
                 values.addAll(processedOption.getValuesList());
             }
         }

--- a/src/main/java/org/apache/commons/cli/CommandLine.java
+++ b/src/main/java/org/apache/commons/cli/CommandLine.java
@@ -314,7 +314,7 @@ public class CommandLine implements Serializable {
     /**
      * Gets the first argument, if any, of this option.
      *
-     * @param option the name of the option.
+     * @param option the option.
      * @return Value of the argument if option is set, and has an argument, otherwise null.
      * @since 1.5.0
      */
@@ -326,7 +326,7 @@ public class CommandLine implements Serializable {
     /**
      * Gets the first argument, if any, of an option.
      *
-     * @param option name of the option.
+     * @param option the option.
      * @param defaultValue is the default value to be returned if the option is not specified.
      * @return Value of the argument if option is set, and has an argument, otherwise {@code defaultValue}.
      * @since 1.5.0
@@ -338,7 +338,7 @@ public class CommandLine implements Serializable {
     /**
      * Gets the first argument, if any, of an option.
      *
-     * @param option name of the option.
+     * @param option the option.
      * @param defaultValue is a supplier for the default value to be returned if the option is not specified.
      * @return Value of the argument if option is set, and has an argument, otherwise {@code defaultValue}.
      * @since 1.7.0
@@ -347,6 +347,44 @@ public class CommandLine implements Serializable {
         final String answer = getOptionValue(option);
         return answer != null ? answer : get(defaultValue);
     }
+
+    /**
+     * Gets the first argument, if any, of this option group.
+     *
+     * @param optionGroup the option group.
+     * @return Value of the argument if option group is selected, and has an argument, otherwise null.
+     * @since 1.9.0
+     */
+    public String getOptionValue(final OptionGroup optionGroup) {
+        final String[] values = getOptionValues(optionGroup);
+        return values == null ? null : values[0];
+    }
+
+    /**
+     * Gets the first argument, if any, of an option group.
+     *
+     * @param optionGroup the option group.
+     * @param defaultValue is the default value to be returned if the option group is not selected.
+     * @return Value of the argument if option group is selected, and has an argument, otherwise {@code defaultValue}.
+     * @since 1.9.0
+     */
+    public String getOptionValue(final OptionGroup optionGroup, final String defaultValue) {
+        return getOptionValue(optionGroup, () -> defaultValue);
+    }
+
+    /**
+     * Gets the first argument, if any, of an option group.
+     *
+     * @param optionGroup the option group..
+     * @param defaultValue is a supplier for the default value to be returned if the option group is not selected.
+     * @return Value of the argument if option group is selected, and has an argument, otherwise {@code defaultValue}.
+     * @since 1.9.0
+     */
+    public String getOptionValue(final OptionGroup optionGroup, final Supplier<String> defaultValue) {
+        final String answer = getOptionValue(optionGroup);
+        return answer != null ? answer : get(defaultValue);
+    }
+
 
     /**
      * Gets the first argument, if any, of this option.
@@ -395,7 +433,7 @@ public class CommandLine implements Serializable {
     /**
      * Gets the array of values, if any, of an option.
      *
-     * @param option string name of the option.
+     * @param option the option.
      * @return Values of the argument if option is set, and has an argument, otherwise null.
      * @since 1.5.0
      */
@@ -413,6 +451,20 @@ public class CommandLine implements Serializable {
             }
         }
         return values.isEmpty() ? null : values.toArray(Util.EMPTY_STRING_ARRAY);
+    }
+
+    /**
+     * Gets the array of values, if any, of an option group.
+     *
+     * @param optionGroup the option group.
+     * @return Values of the argument if option group is selected, and has an argument, otherwise null.
+     * @since 1.9.0
+     */
+    public String[] getOptionValues(final OptionGroup optionGroup) {
+        if (optionGroup == null || !optionGroup.isSelected()) {
+            return null;
+        }
+        return getOptionValues(optionGroup.getSelected());
     }
 
     /**
@@ -472,7 +524,7 @@ public class CommandLine implements Serializable {
     /**
      * Gets a version of this {@code Option} converted to a particular type.
      *
-     * @param option the name of the option.
+     * @param option the option.
      * @param <T> The return type for the method.
      * @return the value parsed into a particular object.
      * @throws ParseException if there are problems turning the option value into the desired type
@@ -486,7 +538,7 @@ public class CommandLine implements Serializable {
     /**
      * Gets a version of this {@code Option} converted to a particular type.
      *
-     * @param option the name of the option.
+     * @param option the option.
      * @param defaultValue the default value to return if opt is not set.
      * @param <T> The return type for the method.
      * @return the value parsed into a particular object.
@@ -513,7 +565,7 @@ public class CommandLine implements Serializable {
     /**
      * Gets a version of this {@code Option} converted to a particular type.
      *
-     * @param option the name of the option.
+     * @param option the option.
      * @param defaultValue the default value to return if opt is not set.
      * @param <T> The return type for the method.
      * @return the value parsed into a particular object.
@@ -523,6 +575,53 @@ public class CommandLine implements Serializable {
      */
     public <T> T getParsedOptionValue(final Option option, final T defaultValue) throws ParseException {
         return getParsedOptionValue(option, () -> defaultValue);
+    }
+
+    /**
+     * Gets a version of this {@code OptionGroup} converted to a particular type.
+     *
+     * @param optionGroup the option group.
+     * @param <T> The return type for the method.
+     * @return the value parsed into a particular object.
+     * @throws ParseException if there are problems turning the selected option value into the desired type
+     * @see PatternOptionBuilder
+     * @since 1.9.0
+     */
+    public <T> T getParsedOptionValue(final OptionGroup optionGroup) throws ParseException {
+        return getParsedOptionValue(optionGroup, () -> null);
+    }
+
+    /**
+     * Gets a version of this {@code OptionGroup} converted to a particular type.
+     *
+     * @param optionGroup the option group.
+     * @param defaultValue the default value to return if opt is not set.
+     * @param <T> The return type for the method.
+     * @return the value parsed into a particular object.
+     * @throws ParseException if there are problems turning the selected option value into the desired type
+     * @see PatternOptionBuilder
+     * @since 1.9.0
+     */
+    public <T> T getParsedOptionValue(final OptionGroup optionGroup, final Supplier<T> defaultValue) throws ParseException {
+        if (optionGroup == null || !optionGroup.isSelected()) {
+            return get(defaultValue);
+        }
+        return getParsedOptionValue(optionGroup.getSelected(), defaultValue);
+    }
+
+    /**
+     * Gets a version of this {@code OptionGroup} converted to a particular type.
+     *
+     * @param optionGroup the option group.
+     * @param defaultValue the default value to return if an option is not selected.
+     * @param <T> The return type for the method.
+     * @return the value parsed into a particular object.
+     * @throws ParseException if there are problems turning the option value into the desired type
+     * @see PatternOptionBuilder
+     * @since 1.9.0
+     */
+    public <T> T getParsedOptionValue(final OptionGroup optionGroup, final T defaultValue) throws ParseException {
+        return getParsedOptionValue(optionGroup, () -> defaultValue);
     }
 
     /**
@@ -621,6 +720,20 @@ public class CommandLine implements Serializable {
             handleDeprecated(opt);
         }
         return result;
+    }
+
+    /**
+     * Tests to see if an option has been set.
+     *
+     * @param optionGroup the option group to check.
+     * @return true if set, false if not.
+     * @since 1.9.0
+     */
+    public boolean hasOption(final OptionGroup optionGroup) {
+        if (optionGroup == null || !optionGroup.isSelected()) {
+            return false;
+        }
+        return hasOption(optionGroup.getSelected());
     }
 
     /**

--- a/src/main/java/org/apache/commons/cli/OptionGroup.java
+++ b/src/main/java/org/apache/commons/cli/OptionGroup.java
@@ -76,6 +76,7 @@ public class OptionGroup implements Serializable {
     /**
      * Gets the selected option name.
      *
+     * If the selected option is deprecated <em>no warning is logged</em>.
      * @return the selected option name.
      */
     public String getSelected() {
@@ -94,6 +95,7 @@ public class OptionGroup implements Serializable {
     /**
      * Tests whether an option is selected.
      *
+     *  If an option is selected and is deprecated <em>no warning is logged</em>.
      * @return whether whether an option is selected.
      * @since 1.9.0
      */
@@ -113,6 +115,7 @@ public class OptionGroup implements Serializable {
     /**
      * Sets the selected option of this group to {@code name}.
      *
+     * If the selected option is deprecated <em>no warning is logged</em>.
      * @param option the option that is selected
      * @throws AlreadySelectedException if an option from this group has already been selected.
      */

--- a/src/test/java/org/apache/commons/cli/CommandLineTest.java
+++ b/src/test/java/org/apache/commons/cli/CommandLineTest.java
@@ -117,6 +117,27 @@ public class CommandLineTest {
     }
 
     @Test
+    public void testDeprecatedOptionGroup() throws Exception {
+        final Options options = new Options();
+        final Option optI = Option.builder("i").hasArg().type(Number.class).build();
+        final Option optF = Option.builder("f").deprecated().hasArg().build();
+        OptionGroup optionGroup = new OptionGroup().addOption(optI).addOption(optF);
+        options.addOptionGroup(optionGroup);
+
+        final List<Option> handler = new ArrayList<>();
+        final CommandLine.Builder builder = new CommandLine.Builder();
+        CommandLineParser parser = DefaultParser.builder().setDeprecatedHandler(handler::add).build();
+        CommandLine cmd = parser.parse(options, new String[] {"-i", "123"});
+        assertEquals(123, ((Number) cmd.getParsedOptionValue(optionGroup)).intValue());
+        assertEquals(0, handler.size());
+
+        cmd = parser.parse(options, new String[] {"-f", "hello"});
+        assertEquals("hello", cmd.getParsedOptionValue(optionGroup));
+        assertEquals(1, handler.size());
+    }
+
+
+    @Test
     public void testDeprecatedParsedOptionValue() throws ParseException {
         final CommandLine.Builder builder = new CommandLine.Builder();
         builder.addArg("foo").addArg("bar");
@@ -295,7 +316,19 @@ public class CommandLineTest {
         final CommandLine cmd = parser.parse(options, new String[] {"-i", "123", "-f", "foo"});
 
         assertEquals(123, ((Number) cmd.getParsedOptionValue(optI)).intValue());
-        assertEquals("foo", cmd.getParsedOptionValue(optF));
+    }
+
+    @Test
+    public void testGetParsedOptionValueWithOptionGroup() throws Exception {
+        final Option optI = Option.builder("i").hasArg().type(Number.class).build();
+        final Option optF = Option.builder("f").deprecated().hasArg().build();
+        OptionGroup optionGroup = new OptionGroup().addOption(optI).addOption(optF);
+        final Options options = new Options().addOptionGroup(optionGroup);
+
+        final CommandLineParser parser = new DefaultParser();
+        final CommandLine cmd = parser.parse(options, new String[] {"-i", "123"});
+
+        assertEquals(123, ((Number) cmd.getParsedOptionValue(optionGroup)).intValue());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/CommandLineTest.java
+++ b/src/test/java/org/apache/commons/cli/CommandLineTest.java
@@ -17,18 +17,25 @@
 
 package org.apache.commons.cli;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class CommandLineTest {
@@ -70,114 +77,14 @@ public class CommandLineTest {
         assertEquals(0, cmd.getOptions().length);
     }
 
-    @Test
-    public void testDeprecatedDefaultOption() {
-        final CommandLine.Builder builder = new CommandLine.Builder();
-        builder.addArg("foo").addArg("bar");
-        final Option opt = Option.builder().option("T").deprecated().build();
-        builder.addOption(opt);
-        final AtomicReference<Option> handler = new AtomicReference<>();
-        final CommandLine cmd = builder.build();
-        cmd.getOptionValue(opt.getOpt());
-        handler.set(null);
-        cmd.getOptionValue("Nope");
-        assertNull(handler.get());
-    }
-
-    @Test
-    public void testDeprecatedOption() {
-        final CommandLine.Builder builder = new CommandLine.Builder();
-        builder.addArg("foo").addArg("bar");
-        final Option opt = Option.builder().option("T").longOpt("tee").deprecated().build();
-        builder.addOption(opt);
-        // verify one and only one call
-        final List<Option> handler = new ArrayList<>();
-        final CommandLine cmd = builder.setDeprecatedHandler(handler::add).build();
-        // test short option arg
-        cmd.getOptionValue(opt.getOpt());
-        assertEquals(1, handler.size());
-        assertSame(opt, handler.get(0));
-        handler.clear();
-
-        // test long option arg
-        cmd.getOptionValue(opt.getLongOpt());
-        assertEquals(1, handler.size());
-        assertSame(opt, handler.get(0));
-        handler.clear();
-
-        // test Option arg
-        cmd.getOptionValue(opt);
-        assertEquals(1, handler.size());
-        assertSame(opt, handler.get(0));
-        handler.clear();
-
-        // test not an option
-        cmd.getOptionValue("Nope");
-        assertEquals(0, handler.size());
-    }
-
-    @Test
-    public void testDeprecatedOptionGroup() throws Exception {
-        final Options options = new Options();
-        final Option optI = Option.builder("i").hasArg().type(Number.class).build();
-        final Option optF = Option.builder("f").deprecated().hasArg().build();
-        OptionGroup optionGroup = new OptionGroup().addOption(optI).addOption(optF);
-        options.addOptionGroup(optionGroup);
-
-        final List<Option> handler = new ArrayList<>();
-        final CommandLine.Builder builder = new CommandLine.Builder();
-        CommandLineParser parser = DefaultParser.builder().setDeprecatedHandler(handler::add).build();
-        CommandLine cmd = parser.parse(options, new String[] {"-i", "123"});
-        assertEquals(123, ((Number) cmd.getParsedOptionValue(optionGroup)).intValue());
-        assertEquals(0, handler.size());
-
-        cmd = parser.parse(options, new String[] {"-f", "hello"});
-        assertEquals("hello", cmd.getParsedOptionValue(optionGroup));
-        assertEquals(1, handler.size());
-    }
-
-
-    @Test
-    public void testDeprecatedParsedOptionValue() throws ParseException {
-        final CommandLine.Builder builder = new CommandLine.Builder();
-        builder.addArg("foo").addArg("bar");
-        final Option opt = Option.builder().option("T").longOpt("tee").deprecated().build();
-        builder.addOption(opt);
-        // verify one and only one call
-        final List<Option> handler = new ArrayList<>();
-        final CommandLine cmd = builder.setDeprecatedHandler(handler::add).build();
-
-        // test short option arg
-        cmd.getParsedOptionValue(opt.getOpt());
-        assertEquals(1, handler.size());
-        assertSame(opt, handler.get(0));
-        handler.clear();
-
-        // test long option arg
-        cmd.getParsedOptionValue(opt.getLongOpt());
-        assertEquals(1, handler.size());
-        assertSame(opt, handler.get(0));
-        handler.clear();
-
-        // test option arg
-        cmd.getParsedOptionValue(opt);
-        assertEquals(1, handler.size());
-        assertSame(opt, handler.get(0));
-        handler.clear();
-
-
-        // test not an option
-        cmd.getParsedOptionValue("Nope");
-        assertEquals(0, handler.size());
-    }
 
     @Test
     public void testGetOptionProperties() throws Exception {
         final String[] args = {"-Dparam1=value1", "-Dparam2=value2", "-Dparam3", "-Dparam4=value4", "-D", "--property", "foo=bar"};
 
         final Options options = new Options();
-        options.addOption(OptionBuilder.withValueSeparator().hasOptionalArgs(2).create('D'));
-        options.addOption(OptionBuilder.withValueSeparator().hasArgs(2).withLongOpt("property").create());
+        options.addOption(Option.builder("D").valueSeparator().optionalArg(true).numberOfArgs(2).build());
+        options.addOption(Option.builder().valueSeparator().numberOfArgs(2).longOpt("property").build());
 
         final Parser parser = new GnuParser();
         final CommandLine cl = parser.parse(options, args);
@@ -198,8 +105,8 @@ public class CommandLineTest {
         final String[] args = {"-Dparam1=value1", "-Dparam2=value2", "-Dparam3", "-Dparam4=value4", "-D", "--property", "foo=bar"};
 
         final Options options = new Options();
-        final Option optionD = OptionBuilder.withValueSeparator().hasOptionalArgs(2).create('D');
-        final Option optionProperty = OptionBuilder.withValueSeparator().hasArgs(2).withLongOpt("property").create();
+        final Option optionD = Option.builder("D").valueSeparator().numberOfArgs(2).optionalArg(true).build();
+        final Option optionProperty = Option.builder().valueSeparator().numberOfArgs(2).longOpt("property").build();
         options.addOption(optionD);
         options.addOption(optionProperty);
 
@@ -248,87 +155,14 @@ public class CommandLineTest {
     @Test
     public void testGetParsedOptionValue() throws Exception {
         final Options options = new Options();
-        options.addOption(OptionBuilder.hasArg().withType(Number.class).create("i"));
-        options.addOption(OptionBuilder.hasArg().create("f"));
-
-        final CommandLineParser parser = new DefaultParser();
-        final CommandLine cmd = parser.parse(options, new String[] {"-i", "123", "-f", "foo"});
-
-        assertEquals(123, ((Number) cmd.getParsedOptionValue("i")).intValue());
-        assertEquals("foo", cmd.getParsedOptionValue("f"));
-    }
-
-    @Test
-    public void testGetParsedOptionValueUsingDefault() throws Exception {
-        final Options options = new Options();
-        final Option optI = Option.builder("i").hasArg().type(Number.class).build();
-        final Option optF = Option.builder("f").hasArg().build();
-        options.addOption(optI);
-        options.addOption(optF);
-
-        final CommandLineParser parser = new DefaultParser();
-        final CommandLine cmd = parser.parse(options, new String[] {"-i", "123"});
-        final Supplier<String> nullSupplier = null;
-
-        assertEquals(123, ((Number) cmd.getParsedOptionValue(optI)).intValue());
-        assertEquals("foo", cmd.getParsedOptionValue(optF, "foo"));
-        assertEquals("foo", cmd.getParsedOptionValue(optF, () -> "foo"));
-        assertNull(cmd.getParsedOptionValue(optF, null));
-        assertNull(cmd.getParsedOptionValue(optF, nullSupplier));
-        assertNull(cmd.getParsedOptionValue(optF, () -> null));
-
-        assertEquals("foo", cmd.getParsedOptionValue("f", "foo"));
-        assertEquals("foo", cmd.getParsedOptionValue("f", () -> "foo"));
-        assertNull(cmd.getParsedOptionValue("f", null));
-        assertNull(cmd.getParsedOptionValue("f", nullSupplier));
-        assertNull(cmd.getParsedOptionValue("f", () -> null));
-
-        assertEquals("foo", cmd.getParsedOptionValue('f', "foo"));
-        assertEquals("foo", cmd.getParsedOptionValue('f', () -> "foo"));
-        assertNull(cmd.getParsedOptionValue('f', null));
-        assertNull(cmd.getParsedOptionValue('f', nullSupplier));
-        assertNull(cmd.getParsedOptionValue('f', () -> null));
-
-    }
-
-    @Test
-    public void testGetParsedOptionValueWithChar() throws Exception {
-        final Options options = new Options();
         options.addOption(Option.builder("i").hasArg().type(Number.class).build());
         options.addOption(Option.builder("f").hasArg().build());
 
         final CommandLineParser parser = new DefaultParser();
         final CommandLine cmd = parser.parse(options, new String[] {"-i", "123", "-f", "foo"});
 
-        assertEquals(123, ((Number) cmd.getParsedOptionValue('i')).intValue());
-        assertEquals("foo", cmd.getParsedOptionValue('f'));
-    }
-
-    @Test
-    public void testGetParsedOptionValueWithOption() throws Exception {
-        final Options options = new Options();
-        final Option optI = Option.builder("i").hasArg().type(Number.class).build();
-        final Option optF = Option.builder("f").hasArg().build();
-        options.addOption(optI);
-        options.addOption(optF);
-
-        final CommandLineParser parser = new DefaultParser();
-        final CommandLine cmd = parser.parse(options, new String[] {"-i", "123", "-f", "foo"});
-
-        assertEquals(123, ((Number) cmd.getParsedOptionValue(optI)).intValue());
-    }
-
-    @Test
-    public void testGetParsedOptionValueWithOptionGroup() throws Exception {
-        final Option optI = Option.builder("i").hasArg().type(Number.class).build();
-        final Option optF = Option.builder("f").deprecated().hasArg().build();
-        OptionGroup optionGroup = new OptionGroup().addOption(optI).addOption(optF);
-        final Options options = new Options().addOptionGroup(optionGroup);
-
-        final CommandLineParser parser = new DefaultParser();
-        final CommandLine cmd = parser.parse(options, new String[] {"-i", "123"});
-
-        assertEquals(123, ((Number) cmd.getParsedOptionValue(optionGroup)).intValue());
+        assertEquals(123, ((Number) cmd.getParsedOptionValue("i")).intValue());
+        assertEquals("foo", cmd.getParsedOptionValue("f"));
     }
 
     @Test
@@ -342,5 +176,371 @@ public class CommandLineTest {
         final CommandLine cmd = parser.parse(options, new String[] {"-i", "123", "-f", "foo"});
         assertNull(cmd.getOptionValue((Option) null));
         assertNull(cmd.getParsedOptionValue((Option) null));
+        assertNull(cmd.getOptionValue((OptionGroup) null));
+        assertNull(cmd.getParsedOptionValue((OptionGroup) null));
     }
+
+    // verifies that the deprecation handler has been called only once or not at all.
+    void checkHandler(boolean optDep, List<Option> handler, Option opt) {
+        if (optDep) {
+            assertEquals(1, handler.size());
+            assertEquals(opt, handler.get(0));
+        } else {
+            assertEquals( 0, handler.size());
+        }
+        handler.clear();
+    }
+
+    /**
+     * Test for get option value with and without default values.  Verifies that deprecated options only report as
+     * deprecated once.
+     * @param args the argument strings to parse.
+     * @param opt the option to check for values with.
+     * @param optionGroup the option group to check for values with.
+     * @param optDep {@code true} if the opt is deprecated.
+     * @param optValue  The value expected from opt.
+     * @param grpDep {@code true} if the group is deprecated.
+     * @param grpValue the value expected from the group.
+     * @param grpOpt the option that is expected to be processed by the group.
+     * @throws ParseException on parse error.
+     */
+    @ParameterizedTest(name = "{0}, {1}")
+    @MethodSource("createOptionValueParameters")
+    public void getOptionValueTest(String[] args, final Option opt, final OptionGroup optionGroup, final boolean optDep, final String optValue, final boolean grpDep, final String grpValue, final Option grpOpt) throws ParseException {
+        final Options options = new Options().addOptionGroup(optionGroup);
+        final List<Option> handler = new ArrayList<>();
+        final CommandLine commandLine = DefaultParser.builder().setDeprecatedHandler(handler::add).build().parse(options, args);
+        final Supplier<String> thinger = () -> {return "thing";};
+        OptionGroup otherGroup = new OptionGroup().addOption(Option.builder("o").longOpt("other").hasArg().build())
+                .addOption(Option.builder().option("p").longOpt("part").hasArg().build());
+
+        // test short option arg
+        assertEquals(optValue, commandLine.getOptionValue(opt.getOpt()));
+        checkHandler(optDep, handler, opt);
+
+        // if null was expected then "thing" is the value
+        assertEquals(optValue==null ? "thing" : optValue, commandLine.getOptionValue(opt.getOpt(), "thing"));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? "thing" : optValue, commandLine.getOptionValue(opt.getOpt(), thinger));
+        checkHandler(optDep, handler, opt);
+
+        // test long option arg
+        assertEquals(optValue, commandLine.getOptionValue(opt.getLongOpt()));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? "thing" : optValue, commandLine.getOptionValue(opt.getLongOpt(), "thing"));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? "thing" : optValue, commandLine.getOptionValue(opt.getLongOpt(), thinger));
+        checkHandler(optDep, handler, opt);
+
+
+        // test Option arg
+        assertEquals(optValue, commandLine.getOptionValue(opt));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? "thing" : optValue, commandLine.getOptionValue(opt, "thing"));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? "thing" : optValue, commandLine.getOptionValue(opt, thinger));
+        checkHandler(optDep, handler, opt);
+
+        // test OptionGroup arg
+        assertEquals("thing", commandLine.getOptionValue(otherGroup, "thing"));
+        checkHandler(false, handler, grpOpt);
+
+        assertEquals("thing", commandLine.getOptionValue(otherGroup, thinger));
+        checkHandler(false, handler, grpOpt);
+
+        // test not an option
+        assertNull(commandLine.getOptionValue("Nope"));
+        checkHandler(false, handler, opt);
+
+        assertEquals("thing", commandLine.getOptionValue("Nope", "thing"));
+        checkHandler(false, handler, opt);
+
+        assertEquals("thing", commandLine.getOptionValue("Nope", thinger));
+        checkHandler(false, handler, opt);
+    }
+
+    private static Stream<Arguments> createOptionValueParameters() throws MalformedURLException, ParseException {
+        List<Arguments> lst = new ArrayList<>();
+        final Option optT = Option.builder().option("T").longOpt("tee").deprecated().optionalArg(true).build();
+        final Option optU = Option.builder("U").longOpt("you").optionalArg(true).build();
+        OptionGroup optionGroup = new OptionGroup().addOption(optT).addOption(optU);
+
+        // T set
+        lst.add(Arguments.of(new String[] {"-T"}, optT, optionGroup, true, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"-T", "foo"}, optT, optionGroup, true, "foo", true, "foo", optT));
+        lst.add(Arguments.of(new String[] {"--tee"}, optT, optionGroup, true, null, true, null, optT ));
+        lst.add(Arguments.of(new String[] {"--tee", "foo"}, optT, optionGroup, true, "foo", true, "foo", optT));
+
+        lst.add(Arguments.of(new String[] {"-U"}, optT, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"-U", "foo"}, optT, optionGroup, false, null, false, "foo", optU));
+        lst.add(Arguments.of(new String[] {"--you"}, optT, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"--you", "foo"}, optT, optionGroup, false, null, false, "foo", optU));
+
+
+        // U set
+        lst.add(Arguments.of(new String[] {"-T"}, optU, optionGroup, false, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"-T", "foo"}, optU, optionGroup, false, null, true, "foo", optT));
+        lst.add(Arguments.of(new String[] {"--tee"}, optU, optionGroup, false, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"--tee", "foo"}, optU, optionGroup, false, null, true, "foo", optT));
+
+        lst.add(Arguments.of(new String[] {"-U"}, optU, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"-U", "foo"}, optU, optionGroup, false, "foo", false, "foo", optU));
+        lst.add(Arguments.of(new String[] {"--you"}, optU, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"--you", "foo"},  optU, optionGroup, false, "foo", false, "foo", optU));
+
+        return lst.stream();
+    }
+
+
+    /**
+     * Test for get option values with and without default values.  Verifies that deprecated options only report as
+     * deprecated once.
+     * @param args the argument strings to parse.
+     * @param opt the option to check for values with.
+     * @param optionGroup the option group to check for values with.
+     * @param optDep {@code true} if the opt is deprecated.
+     * @param optValue  The value expected from opt.
+     * @param grpDep {@code true} if the group is deprecated.
+     * @param grpValue the value expected from the group.
+     * @param grpOpt the option that is expected to be processed by the group.
+     * @throws ParseException on parse error.
+     */
+    @ParameterizedTest(name = "{0}, {1}")
+    @MethodSource("createOptionValuesParameters")
+    public void getOptionValuesTest(String[] args, final Option opt, final OptionGroup optionGroup, final boolean optDep, final String[] optValue, final boolean grpDep, final String[] grpValue, final Option grpOpt) throws ParseException {
+        final Options options = new Options().addOptionGroup(optionGroup);
+        final List<Option> handler = new ArrayList<>();
+        final CommandLine commandLine = DefaultParser.builder().setDeprecatedHandler(handler::add).build().parse(options, args);
+        final String[] things = {"thing1", "thing2"};
+        final Supplier<String[]> thinger = () -> {return new String[]{"thing1", "thing2"};};
+        OptionGroup otherGroup = new OptionGroup().addOption(Option.builder("o").longOpt("other").hasArg().build())
+                .addOption(Option.builder().option("p").longOpt("part").hasArg().build());
+
+        // test short option arg
+        assertArrayEquals(optValue, commandLine.getOptionValues(opt.getOpt()));
+        checkHandler(optDep, handler, opt);
+
+        // test long option arg
+        assertArrayEquals(optValue, commandLine.getOptionValues(opt.getLongOpt()));
+        checkHandler(optDep, handler, opt);
+
+        // test Option arg
+        assertArrayEquals(optValue, commandLine.getOptionValues(opt));
+        checkHandler(optDep, handler, opt);
+
+
+        // test OptionGroup arg
+        assertArrayEquals(grpValue, commandLine.getOptionValues(optionGroup));
+        checkHandler(grpDep, handler, grpOpt);
+
+        // test not an option
+        assertNull(commandLine.getOptionValues("Nope"));
+        checkHandler(false, handler, opt);
+    }
+
+    private static Stream<Arguments> createOptionValuesParameters() throws MalformedURLException, ParseException {
+        List<Arguments> lst = new ArrayList<>();
+        final Option optT = Option.builder().option("T").longOpt("tee").numberOfArgs(2).deprecated().optionalArg(true).build();
+        final Option optU = Option.builder("U").longOpt("you").numberOfArgs(2).optionalArg(true).build();
+        final OptionGroup optionGroup = new OptionGroup().addOption(optT).addOption(optU);
+
+        String[] foobar = { "foo", "bar" };
+        // T set
+        lst.add(Arguments.of(new String[] {"-T"}, optT, optionGroup, true, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"-T", "foo", "bar"}, optT, optionGroup, true, foobar, true, foobar, optT));
+        lst.add(Arguments.of(new String[] {"--tee"}, optT, optionGroup, true, null, true, null, optT ));
+        lst.add(Arguments.of(new String[] {"--tee", "foo", "bar"}, optT, optionGroup, true, foobar, true, foobar, optT));
+
+        lst.add(Arguments.of(new String[] {"-U"}, optT, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"-U", "foo", "bar"}, optT, optionGroup, false, null, false, foobar, optU));
+        lst.add(Arguments.of(new String[] {"--you"}, optT, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"--you", "foo", "bar"}, optT, optionGroup, false, null, false, foobar, optU));
+
+
+        // U set
+        lst.add(Arguments.of(new String[] {"-T"}, optU, optionGroup, false, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"-T", "foo", "bar"}, optU, optionGroup, false, null, true, foobar, optT));
+        lst.add(Arguments.of(new String[] {"--tee"}, optU, optionGroup, false, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"--tee", "foo", "bar"}, optU, optionGroup, false, null, true, foobar, optT));
+
+        lst.add(Arguments.of(new String[] {"-U"}, optU, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"-U", "foo", "bar"}, optU, optionGroup, false, foobar, false, foobar, optU));
+        lst.add(Arguments.of(new String[] {"--you"}, optU, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"--you", "foo", "bar"},  optU, optionGroup, false, foobar, false, foobar, optU));
+
+        return lst.stream();
+    }
+
+    /**
+     * Tests the hasOption calls.
+     * @param args the argument strings to parse.
+     * @param opt the option to check for values with.
+     * @param optionGroup the option group to check for values with.
+     * @param optDep {@code true} if the opt is deprecated.
+     * @param has {@code true} if the opt is present.
+     * @param grpDep {@code true} if the group is deprecated.
+     * @param hasGrp {@code true} if the group is present.
+     * @param grpOpt the option that is expected to be processed by the group.
+     * @throws ParseException on parsing error.
+     */
+    @ParameterizedTest(name = "{0}, {1}")
+    @MethodSource("createHasOptionParameters")
+    public void hasOptionTest(String[] args, final Option opt, final OptionGroup optionGroup, final boolean optDep, final boolean has, final boolean grpDep, final boolean hasGrp, final Option grpOpt) throws ParseException {
+        final Options options = new Options().addOptionGroup(optionGroup);
+        final List<Option> handler = new ArrayList<>();
+        final CommandLine commandLine = DefaultParser.builder().setDeprecatedHandler(handler::add).build().parse(options, args);
+
+        // test short option arg
+        assertEquals(has, commandLine.hasOption(opt.getOpt()));
+        checkHandler(optDep, handler, opt);
+
+        // test long option arg
+        assertEquals(has, commandLine.hasOption(opt.getLongOpt()));
+        checkHandler(optDep, handler, opt);
+
+        // test Option arg
+        assertEquals(has, commandLine.hasOption(opt));
+        checkHandler(optDep, handler, opt);
+
+        // test OptionGroup arg
+        assertEquals(hasGrp, commandLine.hasOption(optionGroup));
+        checkHandler(grpDep, handler, grpOpt);
+
+        // test not an option
+        assertFalse(commandLine.hasOption("Nope"));
+        checkHandler(false, handler, opt);
+    }
+
+    private static Stream<Arguments> createHasOptionParameters() throws MalformedURLException, ParseException {
+        List<Arguments> lst = new ArrayList<>();
+        final Option optT = Option.builder().option("T").longOpt("tee").deprecated().optionalArg(true).build();
+        final Option optU = Option.builder("U").longOpt("you").optionalArg(true).build();
+        final OptionGroup optionGroup = new OptionGroup().addOption(optT).addOption(optU);
+
+        String[] foobar = { "foo", "bar" };
+        // T set
+        lst.add(Arguments.of(new String[] {"-T"}, optT, optionGroup, true, true, true, true, optT));
+        lst.add(Arguments.of(new String[] {"-T", "foo"}, optT, optionGroup, true, true, true, true, optT));
+        lst.add(Arguments.of(new String[] {"--tee"}, optT, optionGroup, true, true, true, true, optT ));
+        lst.add(Arguments.of(new String[] {"--tee", "foo"}, optT, optionGroup, true, true, true, true, optT));
+
+        lst.add(Arguments.of(new String[] {"-U"}, optT, optionGroup, false, false, false, true, optU));
+        lst.add(Arguments.of(new String[] {"-U", "foo", "bar"}, optT, optionGroup, false, false, false, true, optU));
+        lst.add(Arguments.of(new String[] {"--you"}, optT, optionGroup, false, false, false, true, optU));
+        lst.add(Arguments.of(new String[] {"--you", "foo", "bar"}, optT, optionGroup, false, false, false, true, optU));
+
+
+        // U set
+        lst.add(Arguments.of(new String[] {"-T"}, optU, optionGroup, false, false, true, true, optT));
+        lst.add(Arguments.of(new String[] {"-T", "foo", "bar"}, optU, optionGroup, false, false, true, true, optT));
+        lst.add(Arguments.of(new String[] {"--tee"}, optU, optionGroup, false, false, true, true, optT));
+        lst.add(Arguments.of(new String[] {"--tee", "foo", "bar"}, optU, optionGroup, false, false, true, true, optT));
+
+        lst.add(Arguments.of(new String[] {"-U"}, optU, optionGroup, false, true, false, true, optU));
+        lst.add(Arguments.of(new String[] {"-U", "foo", "bar"}, optU, optionGroup, false, true, false, true, optU));
+        lst.add(Arguments.of(new String[] {"--you"}, optU, optionGroup, false, true, false, true, optU));
+        lst.add(Arguments.of(new String[] {"--you", "foo", "bar"},  optU, optionGroup, false, true, false, true, optU));
+
+        return lst.stream();
+    }
+
+    @ParameterizedTest(name = "{0}, {1}")
+    @MethodSource("createParsedOptionValueParameters")
+    public void getParsedOptionValueTest(String[] args, final Option opt, final OptionGroup optionGroup, final boolean optDep, final Integer optValue, final boolean grpDep, final Integer grpValue, final Option grpOpt) throws ParseException {
+        final Options options = new Options().addOptionGroup(optionGroup);
+        final List<Option> handler = new ArrayList<>();
+        final CommandLine commandLine = DefaultParser.builder().setDeprecatedHandler(handler::add).build().parse(options, args);
+        final Supplier<Integer> thinger = () -> {return 2;};
+        OptionGroup otherGroup = new OptionGroup().addOption(Option.builder("o").longOpt("other").hasArg().build())
+                .addOption(Option.builder().option("p").longOpt("part").hasArg().build());
+        Integer thing = 2;
+
+        // test short option arg
+        assertEquals(optValue, commandLine.getParsedOptionValue(opt.getOpt()));
+        checkHandler(optDep, handler, opt);
+
+        // if null was expected then "thing" is the value
+        assertEquals(optValue==null ? thing : optValue, commandLine.getParsedOptionValue(opt.getOpt(), thing));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? thing : optValue, commandLine.getParsedOptionValue(opt.getOpt(), thinger));
+        checkHandler(optDep, handler, opt);
+
+        // test long option arg
+        assertEquals(optValue, commandLine.getParsedOptionValue(opt.getLongOpt()));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? thing : optValue, commandLine.getParsedOptionValue(opt.getLongOpt(), thing));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? thing : optValue, commandLine.getParsedOptionValue(opt.getLongOpt(), thinger));
+        checkHandler(optDep, handler, opt);
+
+
+        // test Option arg
+        assertEquals(optValue, commandLine.getParsedOptionValue(opt));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? thing : optValue, commandLine.getParsedOptionValue(opt, thing));
+        checkHandler(optDep, handler, opt);
+
+        assertEquals(optValue==null ? thing : optValue, commandLine.getParsedOptionValue(opt, thinger));
+        checkHandler(optDep, handler, opt);
+
+        // test OptionGroup arg
+        assertEquals(thing, commandLine.getParsedOptionValue(otherGroup, thing));
+        checkHandler(false, handler, grpOpt);
+
+        assertEquals(thing, commandLine.getParsedOptionValue(otherGroup, thinger));
+        checkHandler(false, handler, grpOpt);
+
+        // test not an option
+        assertNull(commandLine.getParsedOptionValue("Nope"));
+        checkHandler(false, handler, opt);
+
+        assertEquals(thing, commandLine.getParsedOptionValue("Nope", thing));
+        checkHandler(false, handler, opt);
+
+        assertEquals(thing, commandLine.getParsedOptionValue("Nope", thinger));
+        checkHandler(false, handler, opt);
+    }
+
+    private static Stream<Arguments> createParsedOptionValueParameters() throws MalformedURLException, ParseException {
+        List<Arguments> lst = new ArrayList<>();
+        final Option optT = Option.builder().option("T").longOpt("tee").deprecated().type(Integer.class).optionalArg(true).build();
+        final Option optU = Option.builder("U").longOpt("you").type(Integer.class).optionalArg(true).build();
+        OptionGroup optionGroup = new OptionGroup().addOption(optT).addOption(optU);
+        Integer expected = Integer.valueOf(1);
+
+        // T set
+        lst.add(Arguments.of(new String[] {"-T"}, optT, optionGroup, true, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"-T", "1"}, optT, optionGroup, true, expected, true, expected, optT));
+        lst.add(Arguments.of(new String[] {"--tee"}, optT, optionGroup, true, null, true, null, optT ));
+        lst.add(Arguments.of(new String[] {"--tee", "1"}, optT, optionGroup, true, expected, true, expected, optT));
+
+        lst.add(Arguments.of(new String[] {"-U"}, optT, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"-U", "1"}, optT, optionGroup, false, null, false, expected, optU));
+        lst.add(Arguments.of(new String[] {"--you"}, optT, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"--you", "1"}, optT, optionGroup, false, null, false, expected, optU));
+
+
+        // U set
+        lst.add(Arguments.of(new String[] {"-T"}, optU, optionGroup, false, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"-T", "1"}, optU, optionGroup, false, null, true, expected, optT));
+        lst.add(Arguments.of(new String[] {"--tee"}, optU, optionGroup, false, null, true, null, optT));
+        lst.add(Arguments.of(new String[] {"--tee", "1"}, optU, optionGroup, false, null, true, expected, optT));
+
+        lst.add(Arguments.of(new String[] {"-U"}, optU, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"-U", "1"}, optU, optionGroup, false, expected, false, expected, optU));
+        lst.add(Arguments.of(new String[] {"--you"}, optU, optionGroup, false, null, false, null, optU));
+        lst.add(Arguments.of(new String[] {"--you", "1"},  optU, optionGroup, false, expected, false, expected, optU));
+
+        return lst.stream();
+    }
+
 }


### PR DESCRIPTION
fixes for CLI-336 

updated javadoc for OptionGroup.getSelected(), OptionGroup.isSelected() and OptionGroup.select() methods to indicate that deprecated options do not trigger logging of deprecated option usage.

CommandLine methods hasOption(OptionGroup), getOptionValue(OptionGroup), getOptionValues(OptionGroup),  and getParsedOptionValue(OptionGroup) methods.