### PR TITLE
Add "since" attribute to Option to track when an Option was introduced.

### DIFF
--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -93,6 +93,9 @@ public class Option implements Cloneable, Serializable {
         /** Specifies whether this option is required to be present. */
         private boolean required;
 
+        /** Specifies the version when this option was added.  May be null */
+        private String since;
+
         /** The type of this Option. */
         private Class<?> type = DEFAULT_TYPE;
 
@@ -282,6 +285,16 @@ public class Option implements Cloneable, Serializable {
             return this;
         }
 
+        /** Sets the version number when this option was first defined."
+         *
+         * @param since the version number when this option was first defined.
+         * @return this builder.
+         */
+        public Builder since(final String since) {
+            this.since = since;
+            return this;
+        }
+
         /**
          * Sets the type of the Option.
          *
@@ -395,6 +408,9 @@ public class Option implements Cloneable, Serializable {
     /** Specifies whether this option is required to be present. */
     private boolean required;
 
+    /** Specifies the version when this option was added.  May be null */
+    private String since;
+
     /** The type of this Option. */
     private Class<?> type = String.class;
 
@@ -418,6 +434,7 @@ public class Option implements Cloneable, Serializable {
         this.optionalArg = builder.optionalArg;
         this.deprecated = builder.deprecated;
         this.required = builder.required;
+        this.since = builder.since;
         this.type = builder.type;
         this.valuesep = builder.valueSeparator;
         this.converter = builder.converter;
@@ -643,6 +660,15 @@ public class Option implements Cloneable, Serializable {
     public String getOpt() {
         return option;
     }
+
+    /**
+     * Gets the version when this option was added.
+     * @return the version when this option was added, or {@code null} if not set.
+     */
+    public String getSince() {
+        return since;
+    }
+
 
     /**
      * Gets the type of this Option.

--- a/src/test/java/org/apache/commons/cli/HelpFormatterTest.java
+++ b/src/test/java/org/apache/commons/cli/HelpFormatterTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.commons.cli;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -491,6 +493,22 @@ public class HelpFormatterTest {
     }
 
     @Test
+    public void testPrintHelpWithSince() {
+        final String [] expected = {"usage: Command syntax", "Header", "Options            Since   Description",
+                "  -n,--no-since    -          Description for n", "  -W,--with-since  1.19.0     Descripton for W", "footer"};
+        final Options options = new Options()
+                .addOption(Option.builder("W").longOpt("with-since").since("1.19.0").desc("Descripton for W").build())
+                .addOption(Option.builder("n").longOpt("no-since").desc("Description for n").build());
+
+        final HelpFormatter formatter = HelpFormatter.builder().setShowSince(true).get();
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(baos))) {
+            formatter.printHelp(pw, 80, "Command syntax", "Header", options, 2, 5, "footer", false);
+        }
+        assertArrayEquals(expected, baos.toString().split(System.lineSeparator()));
+    }
+
+    @Test
     public void testPrintOptionGroupUsage() {
         final OptionGroup group = new OptionGroup();
         group.addOption(Option.builder("a").build());
@@ -636,6 +654,20 @@ public class HelpFormatterTest {
             helpFormatter.printUsage(printWriter, 80, "app", opts);
         }
         assertEquals("usage: app [-a] [-b] [-c]" + EOL, bytesOut.toString());
+    }
+
+    @Test
+    public void testRenderSince() {
+        final String[] expected = {"Options            Since   Description", "  -n,--no-since    -          Description for n",
+            "  -W,--with-since  1.19.0     Descripton for W"};
+        final Options options = new Options()
+                .addOption(Option.builder("W").longOpt("with-since").since("1.19.0").desc("Descripton for W").build())
+                .addOption(Option.builder("n").longOpt("no-since").desc("Description for n").build());
+        final HelpFormatter formatter = HelpFormatter.builder().setShowSince(true).get();
+
+        final StringBuffer sb = new StringBuffer();
+        formatter.renderOptions(sb, 50, options, 2, 5);
+        assertArrayEquals(expected, sb.toString().split(System.lineSeparator()));
     }
 
     @Test


### PR DESCRIPTION
Adds a `since` attribute to options but does not modify the display by default.
Adds `showSince` to HelpFormatter and HelpFormatter.Builder

When `since` is shown a header line above the Option listing is added delineating the  "Options", "Since", and "Description" sections.

Appropriate tests were added.
