### PR TITLE
Migrate Java 8 to Java 21 in the entire repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,9 @@
   </dependencies>
   <properties>
     <project.build.outputTimestamp>2024-08-14T23:15:56Z</project.build.outputTimestamp>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.release>21</maven.compiler.release>
     <commons.componentid>cli</commons.componentid>
     <commons.module.name>org.apache.commons.cli</commons.module.name>
     <commons.release.version>1.10.0</commons.release.version>

--- a/src/main/java/org/apache/commons/cli/BasicParser.java
+++ b/src/main/java/org/apache/commons/cli/BasicParser.java
@@ -23,7 +23,7 @@ package org.apache.commons.cli;
  *
  * @deprecated since 1.3, use the {@link DefaultParser} instead
  */
-@Deprecated
+@Deprecated(since = "1.3")
 public class BasicParser extends Parser {
     /**
      * <p>

--- a/src/main/java/org/apache/commons/cli/CommandLine.java
+++ b/src/main/java/org/apache/commons/cli/CommandLine.java
@@ -67,7 +67,7 @@ public class CommandLine implements Serializable {
          *
          * @deprecated Use {@link #builder()}.
          */
-        @Deprecated
+        @Deprecated(since = "1.4")
         public Builder() {
             // empty
         }
@@ -106,7 +106,7 @@ public class CommandLine implements Serializable {
          * @return a new instance.
          * @deprecated Use {@link #get()}.
          */
-        @Deprecated
+        @Deprecated(since = "1.4")
         public CommandLine build() {
             return get();
         }
@@ -229,7 +229,7 @@ public class CommandLine implements Serializable {
      * @param opt the name of the option.
      * @return the type of opt.
      */
-    @Deprecated
+    @Deprecated(since = "1.0")
     public Object getOptionObject(final char opt) {
         return getOptionObject(String.valueOf(opt));
     }
@@ -241,7 +241,7 @@ public class CommandLine implements Serializable {
      * @return the type of this {@code Option}.
      * @deprecated due to System.err message. Instead use getParsedOptionValue(String)
      */
-    @Deprecated
+    @Deprecated(since = "1.0")
     public Object getOptionObject(final String opt) {
         try {
             return getParsedOptionValue(opt);

--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -18,6 +18,7 @@ package org.apache.commons.cli;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -71,7 +72,7 @@ public interface Converter<T, E extends Exception> {
     /**
      * Creates a URL. Calls {@link URL#URL(String)}.
      */
-    Converter<URL, MalformedURLException> URL = URL::new;
+    Converter<URL, MalformedURLException> URL = s -> URI.create(s).toURL();
 
     /**
      * Converts to a date using the format string Form "EEE MMM dd HH:mm:ss zzz yyyy".

--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -77,7 +77,7 @@ public class DefaultParser implements CommandLineParser {
          * @since 1.5.0
          * @deprecated Use {@link #get()}.
          */
-        @Deprecated
+        @Deprecated(since = "1.5.0")
         public DefaultParser build() {
             return get();
         }

--- a/src/main/java/org/apache/commons/cli/DeprecatedAttributes.java
+++ b/src/main/java/org/apache/commons/cli/DeprecatedAttributes.java
@@ -60,7 +60,7 @@ public final class DeprecatedAttributes {
          *
          * @deprecated Use {@link #builder()}.
          */
-        @Deprecated
+        @Deprecated(since = "1.7.0")
         public Builder() {
             // empty
         }

--- a/src/main/java/org/apache/commons/cli/GnuParser.java
+++ b/src/main/java/org/apache/commons/cli/GnuParser.java
@@ -26,7 +26,7 @@ import java.util.List;
  *
  * @deprecated since 1.3, use the {@link DefaultParser} instead
  */
-@Deprecated
+@Deprecated(since = "1.3")
 public class GnuParser extends Parser {
     /**
      * This flatten method does so using the following rules:

--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -518,7 +518,7 @@ public class Option implements Cloneable, Serializable {
      * @throws UnsupportedOperationException always.
      * @deprecated Unused.
      */
-    @Deprecated
+    @Deprecated(since = "1.0")
     public boolean addValue(final String value) {
         throw new UnsupportedOperationException(
                 "The addValue method is not intended for client use. Subclasses should use the processValue method instead.");
@@ -961,7 +961,7 @@ public class Option implements Cloneable, Serializable {
      * @param type the type of this Option.
      * @deprecated since 1.3, use {@link #setType(Class)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "1.3")
     public void setType(final Object type) {
         setType((Class<?>) type);
     }
@@ -1011,7 +1011,7 @@ public class Option implements Cloneable, Serializable {
         }
         if (hasArgs()) {
             buf.append("[ARG...]");
-        } else if (hasArg()) {
+        } else if (hasArg())  {
             buf.append(" [ARG]");
         }
         // @formatter:off

--- a/src/main/java/org/apache/commons/cli/OptionBuilder.java
+++ b/src/main/java/org/apache/commons/cli/OptionBuilder.java
@@ -28,7 +28,7 @@ package org.apache.commons.cli;
  * @since 1.0
  * @deprecated since 1.3, use {@link Option#builder(String)} instead
  */
-@Deprecated
+@Deprecated(since = "1.3")
 public final class OptionBuilder {
 
     /** Long option */
@@ -286,7 +286,7 @@ public final class OptionBuilder {
      * @return the OptionBuilder instance
      * @deprecated since 1.3, use {@link #withType(Class)} instead
      */
-    @Deprecated
+    @Deprecated(since = "1.3")
     public static OptionBuilder withType(final Object newType) {
         return withType((Class<?>) newType);
     }

--- a/src/main/java/org/apache/commons/cli/Parser.java
+++ b/src/main/java/org/apache/commons/cli/Parser.java
@@ -29,7 +29,7 @@ import java.util.Properties;
  *
  * @deprecated since 1.3, the two-pass parsing with the flatten method is not enough flexible to handle complex cases
  */
-@Deprecated
+@Deprecated(since = "1.3")
 public abstract class Parser implements CommandLineParser {
     /** CommandLine instance */
     protected CommandLine cmd;
@@ -327,5 +327,4 @@ public abstract class Parser implements CommandLineParser {
             group.setSelected(opt);
         }
     }
-
 }

--- a/src/main/java/org/apache/commons/cli/PatternOptionBuilder.java
+++ b/src/main/java/org/apache/commons/cli/PatternOptionBuilder.java
@@ -117,7 +117,7 @@ public class PatternOptionBuilder {
      * @return The class that {@code ch} represents
      * @deprecated use {@link #getValueType(char)}
      */
-    @Deprecated // since="1.7.0"
+    @Deprecated(since = "1.7.0")
     public static Object getValueClass(final char ch) {
         return getValueType(ch);
     }
@@ -130,28 +130,18 @@ public class PatternOptionBuilder {
      * @since 1.7.0
      */
     public static Class<?> getValueType(final char ch) {
-        switch (ch) {
-        case '@':
-            return OBJECT_VALUE;
-        case ':':
-            return STRING_VALUE;
-        case '%':
-            return NUMBER_VALUE;
-        case '+':
-            return CLASS_VALUE;
-        case '#':
-            return DATE_VALUE;
-        case '<':
-            return EXISTING_FILE_VALUE;
-        case '>':
-            return FILE_VALUE;
-        case '*':
-            return FILES_VALUE;
-        case '/':
-            return URL_VALUE;
-        }
-
-        return null;
+        return switch (ch) {
+            case '@' -> OBJECT_VALUE;
+            case ':' -> STRING_VALUE;
+            case '%' -> NUMBER_VALUE;
+            case '+' -> CLASS_VALUE;
+            case '#' -> DATE_VALUE;
+            case '<' -> EXISTING_FILE_VALUE;
+            case '>' -> FILE_VALUE;
+            case '*' -> FILES_VALUE;
+            case '/' -> URL_VALUE;
+            default -> null;
+        };
     }
 
     /**

--- a/src/main/java/org/apache/commons/cli/PosixParser.java
+++ b/src/main/java/org/apache/commons/cli/PosixParser.java
@@ -28,7 +28,7 @@ import java.util.List;
  *
  * @deprecated since 1.3, use the {@link DefaultParser} instead
  */
-@Deprecated
+@Deprecated(since = "1.3")
 public class PosixParser extends Parser {
     /** Holder for flattened tokens */
     private final List<String> tokens = new ArrayList<>();

--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -103,7 +103,7 @@ public class TypeHandler {
      * @throws UnsupportedOperationException always
      * @deprecated with no replacement
      */
-    @Deprecated // since 1.7.0
+    @Deprecated(since = "1.7.0")
     public static File[] createFiles(final String string) {
         // to implement/port:
         // return FileW.findFiles(string);
@@ -117,7 +117,7 @@ public class TypeHandler {
      * @return the number represented by {@code string}
      * @throws ParseException if {@code string} is not a number
      */
-    @Deprecated // since 1.7.0
+    @Deprecated(since = "1.7.0")
     public static Number createNumber(final String string) throws ParseException {
         return createValue(string, Number.class);
     }
@@ -130,7 +130,7 @@ public class TypeHandler {
      * @throws ParseException if the class could not be found or the object could not be created
      * @deprecated use {@link #createValue(String, Class)}
      */
-    @Deprecated // since 1.7.0
+    @Deprecated(since = "1.7.0")
     public static Object createObject(final String className) throws ParseException {
         return createValue(className, Object.class);
     }
@@ -172,7 +172,7 @@ public class TypeHandler {
      * @throws ParseException if the value creation for the given object type failed
      * @deprecated use {@link #createValue(String, Class)}
      */
-    @Deprecated // since 1.7.0
+    @Deprecated(since = "1.7.0")
     public static Object createValue(final String string, final Object obj) throws ParseException {
         return createValue(string, (Class<?>) obj);
     }
@@ -212,7 +212,7 @@ public class TypeHandler {
      * @throws ParseException if the file is not exist or not readable
      * @deprecated use {@link #createValue(String, Class)}
      */
-    @Deprecated // since 1.7.0
+    @Deprecated(since = "1.7.0")
     public static FileInputStream openFile(final String string) throws ParseException {
         return createValue(string, FileInputStream.class);
     }

--- a/src/main/java/org/apache/commons/cli/help/TextStyle.java
+++ b/src/main/java/org/apache/commons/cli/help/TextStyle.java
@@ -345,47 +345,43 @@ public final class TextStyle {
         if (text.length() >= maxWidth) {
             return text;
         }
-        String indentPad;
-        String rest;
         final StringBuilder sb = new StringBuilder();
-        switch (alignment) {
-        case CENTER:
-            int padLen;
-            if (maxWidth == UNSET_MAX_WIDTH) {
-                padLen = addIndent ? indent : 0;
-            } else {
-                padLen = maxWidth - text.length();
-            }
-            final int left = padLen / 2;
-            indentPad = Util.repeatSpace(left);
-            rest = Util.repeatSpace(padLen - left);
-            sb.append(indentPad).append(text).append(rest);
-            break;
-        case LEFT:
-        case RIGHT:
-        default: // default should never happen. It is here to keep code coverage happy.
-            if (maxWidth == UNSET_MAX_WIDTH) {
-                indentPad = addIndent ? Util.repeatSpace(indent) : "";
-                rest = "";
-            } else {
-                int restLen = maxWidth - text.length();
-                if (addIndent && restLen > indent) {
-                    indentPad = Util.repeatSpace(indent);
-                    restLen -= indent;
+        return switch (alignment) {
+            case CENTER -> {
+                int padLen;
+                if (maxWidth == UNSET_MAX_WIDTH) {
+                    padLen = addIndent ? indent : 0;
                 } else {
-                    indentPad = "";
+                    padLen = maxWidth - text.length();
                 }
-                rest = Util.repeatSpace(restLen);
+                final int left = padLen / 2;
+                String indentPad = Util.repeatSpace(left);
+                String rest = Util.repeatSpace(padLen - left);
+                yield sb.append(indentPad).append(text).append(rest).toString();
             }
-
-            if (alignment == Alignment.LEFT) {
-                sb.append(indentPad).append(text).append(rest);
-            } else {
-                sb.append(indentPad).append(rest).append(text);
+            case LEFT, RIGHT -> {
+                String indentPad;
+                String rest;
+                if (maxWidth == UNSET_MAX_WIDTH) {
+                    indentPad = addIndent ? Util.repeatSpace(indent) : "";
+                    rest = "";
+                } else {
+                    int restLen = maxWidth - text.length();
+                    if (addIndent && restLen > indent) {
+                        indentPad = Util.repeatSpace(indent);
+                        restLen -= indent;
+                    } else {
+                        indentPad = "";
+                    }
+                    rest = Util.repeatSpace(restLen);
+                }
+                if (alignment == Alignment.LEFT) {
+                    yield sb.append(indentPad).append(text).append(rest).toString();
+                } else {
+                    yield sb.append(indentPad).append(rest).append(text).toString();
+                }
             }
-            break;
-        }
-        return sb.toString();
+        };
     }
 
     @Override

--- a/src/test/java/org/apache/commons/cli/AbstractParserTestCase.java
+++ b/src/test/java/org/apache/commons/cli/AbstractParserTestCase.java
@@ -144,8 +144,7 @@ public abstract class AbstractParserTestCase {
 
     @Test
     public void testArgumentStartingWithHyphen() throws Exception {
-        final String[] args = { "-b", "-foo" };
-        final CommandLine cl = parser.parse(options, args);
+        final CommandLine cl = parser.parse(options, new String[] { "-b", "-foo" });
         assertEquals("-foo", cl.getOptionValue("b"));
     }
 

--- a/src/test/java/org/apache/commons/cli/ApplicationTest.java
+++ b/src/test/java/org/apache/commons/cli/ApplicationTest.java
@@ -231,47 +231,48 @@ public class ApplicationTest {
         final StringWriter out = new StringWriter();
         hf.printHelp(new PrintWriter(out), 60, cmdLine, null, options, HelpFormatter.DEFAULT_LEFT_PAD, HelpFormatter.DEFAULT_DESC_PAD, null, false);
         //@formatter:off
-        assertEquals("usage: man [-c|-f|-k|-w|-tZT device] [-adlhu7V] [-Mpath]" + eol +
-                        "           [-Ppager] [-Slist] [-msystem] [-pstring]" + eol +
-                        "           [-Llocale] [-eextension] [section] page ..." + eol +
-                        " -7,--ascii                display ASCII translation or" + eol +
-                        "                           certain latin1 chars." + eol +
-                        " -a,--all                  find all matching manual pages." + eol +
-                        " -c,--catman               used by catman to reformat out of" + eol +
-                        "                           date cat pages." + eol +
-                        " -d,--debug                emit debugging messages." + eol +
-                        " -D,--default              reset all options to their" + eol +
-                        "                           default values." + eol +
-                        " -e,--extension            limit search to extension type" + eol +
-                        "                           'extension'." + eol +
-                        " -f,--whatis               equivalent to whatis." + eol +
-                        " -h,--help                 show this usage message." + eol +
-                        " -k,--apropos              equivalent to apropos." + eol +
-                        " -l,--local-file           interpret 'page' argument(s) as" + eol +
-                        "                           local file name(s)" + eol +
-                        " -L,--locale <arg>         define the locale for this" + eol +
-                        "                           particular man search." + eol +
-                        " -M,--manpath <arg>        set search path for manual pages" + eol +
-                        "                           to 'path'." + eol +
-                        " -m,--systems <arg>        search for man pages from other" + eol +
-                        "                           UNIX system(s)." + eol +
-                        " -P,--pager <arg>          use program 'pager' to display" + eol +
-                        "                           output." + eol +
-                        " -p,--preprocessor <arg>   string indicates which" + eol +
-                        "                           preprocessor to run." + eol +
-                        "                           e - [n]eqn  p - pic     t - tbl" + eol +
-                        "                           g - grap    r - refer   v -" + eol +
-                        "                           vgrind" + eol +
-                        " -r,--prompt <arg>         provide 'less' pager with prompt." + eol +
-                        " -S,--sections <arg>       use colon separated section list." + eol +
-                        " -t,--troff                use troff format pages." + eol +
-                        " -T,--troff-device <arg>   use groff with selected device." + eol +
-                        " -u,--update               force a cache consistency check." + eol +
-                        " -V,--version              show version." + eol +
-                        " -w,--location             print physical location of man" + eol +
-                        "                           page(s)." + eol +
-                        " -Z,--ditroff              use groff with selected device." + eol,
-                out.toString());
+        assertEquals("""
+            usage: man [-c|-f|-k|-w|-tZT device] [-adlhu7V] [-Mpath]
+                       [-Ppager] [-Slist] [-msystem] [-pstring]
+                       [-Llocale] [-eextension] [section] page ...
+             -7,--ascii                display ASCII translation or
+                                       certain latin1 chars.
+             -a,--all                  find all matching manual pages.
+             -c,--catman               used by catman to reformat out of
+                                       date cat pages.
+             -d,--debug                emit debugging messages.
+             -D,--default              reset all options to their
+                                       default values.
+             -e,--extension            limit search to extension type
+                                       'extension'.
+             -f,--whatis               equivalent to whatis.
+             -h,--help                 show this usage message.
+             -k,--apropos              equivalent to apropos.
+             -l,--local-file           interpret 'page' argument(s) as
+                                       local file name(s)
+             -L,--locale <arg>         define the locale for this
+                                       particular man search.
+             -M,--manpath <arg>        set search path for manual pages
+                                       to 'path'.
+             -m,--systems <arg>        search for man pages from other
+                                       UNIX system(s).
+             -P,--pager <arg>          use program 'pager' to display
+                                       output.
+             -p,--preprocessor <arg>   string indicates which
+                                       preprocessor to run.
+                                       e - [n]eqn  p - pic     t - tbl
+                                       g - grap    r - refer   v -
+                                       vgrind
+             -r,--prompt <arg>         provide 'less' pager with prompt.
+             -S,--sections <arg>       use colon separated section list.
+             -t,--troff                use troff format pages.
+             -T,--troff-device <arg>   use groff with selected device.
+             -u,--update               force a cache consistency check.
+             -V,--version              show version.
+             -w,--location             print physical location of man
+                                       page(s).
+             -Z,--ditroff              use groff with selected device.
+            """, out.toString());
         //@formatter:on
     }
 

--- a/src/test/java/org/apache/commons/cli/ArgumentIsOptionTest.java
+++ b/src/test/java/org/apache/commons/cli/ArgumentIsOptionTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@Deprecated(since = "1.3")
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class ArgumentIsOptionTest {
 

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.net.URI;
 import java.net.URL;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -122,7 +123,7 @@ public class ConverterTests {
 
     @Test
     public void testUrl() throws Exception {
-        assertEquals(new URL("http://apache.org"), Converter.URL.apply("http://apache.org"));
-        assertThrows(java.net.MalformedURLException.class, () -> Converter.URL.apply("foo.bar"));
+        assertEquals(URI.create("http://apache.org").toURL(), Converter.URL.apply("http://apache.org"));
+        assertThrows(java.lang.IllegalArgumentException.class, () -> Converter.URL.apply("foo.bar"));
     }
 }

--- a/src/test/java/org/apache/commons/cli/OptionValidatorTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionValidatorTest.java
@@ -71,7 +71,6 @@ public class OptionValidatorTest {
     private static String notRestChars;
 
     private static Stream<Arguments> optionParameters() {
-
         final List<Arguments> args = new ArrayList<>();
 
         args.add(Arguments.of("CamelCase", true, "Camel case error"));
@@ -156,7 +155,6 @@ public class OptionValidatorTest {
             }
         }
         notRestChars = sb.toString();
-
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
+++ b/src/test/java/org/apache/commons/cli/PatternOptionBuilderTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.URL;
+import java.net.URI;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -131,7 +131,7 @@ public class PatternOptionBuilderTest {
         assertEquals(new File("build.xml"), line.getOptionObject("e"), "file flag e");
         assertEquals(Calendar.class, line.getOptionObject("f"), "class flag f");
         assertEquals(Double.valueOf(4.5), line.getOptionObject("n"), "number flag n");
-        assertEquals(new URL("https://commons.apache.org"), line.getOptionObject("t"), "url flag t");
+        assertEquals(URI.create("https://commons.apache.org").toURL(), line.getOptionObject("t"), "url flag t");
         // tests the char methods of CommandLine that delegate to the String methods
         assertEquals("foo", line.getOptionValue('a'), "flag a");
         assertEquals("foo", line.getOptionObject('a'), "string flag a");
@@ -141,11 +141,10 @@ public class PatternOptionBuilderTest {
         assertEquals(new File("build.xml"), line.getOptionObject('e'), "file flag e");
         assertEquals(Calendar.class, line.getOptionObject('f'), "class flag f");
         assertEquals(Double.valueOf(4.5), line.getOptionObject('n'), "number flag n");
-        assertEquals(new URL("https://commons.apache.org"), line.getOptionObject('t'), "url flag t");
+        assertEquals(URI.create("https://commons.apache.org").toURL(), line.getOptionObject('t'), "url flag t");
         // FILES NOT SUPPORTED YET
         assertThrows(UnsupportedOperationException.class, () -> line.getOptionObject('m'));
         assertEquals(expectedDate, line.getOptionObject('z'), "date flag z");
-
     }
 
     @Test
@@ -166,7 +165,7 @@ public class PatternOptionBuilderTest {
         final Options options = PatternOptionBuilder.parsePattern("u/v/");
         final CommandLineParser parser = new PosixParser();
         final CommandLine line = parser.parse(options, new String[] {"-u", "https://commons.apache.org", "-v", "foo://commons.apache.org"});
-        assertEquals(new URL("https://commons.apache.org"), line.getOptionObject("u"), "u value");
+        assertEquals(URI.create("https://commons.apache.org").toURL(), line.getOptionObject("u"), "u value");
         assertNull(line.getOptionObject("v"), "v value");
     }
 }

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -161,11 +162,10 @@ public class TypeHandlerTest {
         list.add(Arguments.of("String", PatternOptionBuilder.STRING_VALUE, "String"));
 
         final String urlString = "https://commons.apache.org";
-        list.add(Arguments.of(urlString, PatternOptionBuilder.URL_VALUE, new URL(urlString)));
+        list.add(Arguments.of(urlString, PatternOptionBuilder.URL_VALUE, URI.create(urlString).toURL()));
         list.add(Arguments.of("Malformed-url", PatternOptionBuilder.URL_VALUE, ParseException.class));
 
         return list.stream();
-
     }
 
     @Test
@@ -257,5 +257,4 @@ public class TypeHandlerTest {
             assertEquals(Converter.DEFAULT, typeHandler.getConverter(Path.class));
         }
     }
-
 }

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI148Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI148Test.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 /**
  * https://issues.apache.org/jira/browse/CLI-148
  */
+@Deprecated(since = "1.3")
 @SuppressWarnings("deprecation") // tests some deprecated classes
 public class BugCLI148Test {
     private Options options;

--- a/src/test/java/org/apache/commons/cli/bug/BugCLI312Test.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugCLI312Test.java
@@ -87,24 +87,12 @@ public class BugCLI312Test {
                 defineOptionsFound++;
 
                 switch (defineOptionsFound) {
-                case 1:
-                    assertArrayEquals(new String[] {"v"}, o.getValues());
-                    break;
-                case 2:
-                    assertArrayEquals(new String[] {"w", "1"}, o.getValues());
-                    break;
-                case 3:
-                    assertArrayEquals(new String[] {"x", "2"}, o.getValues());
-                    break;
-                case 4:
-                    assertArrayEquals(new String[] {"y"}, o.getValues());
-                    break;
-                case 5:
-                    assertArrayEquals(new String[] {"z", "3"}, o.getValues());
-                    break;
-                default:
-                    fail("Didn't expect " + defineOptionsFound + " occurrences of -D");
-                    break;
+                    case 1 -> assertArrayEquals(new String[] {"v"}, o.getValues());
+                    case 2 -> assertArrayEquals(new String[] {"w", "1"}, o.getValues());
+                    case 3 -> assertArrayEquals(new String[] {"x", "2"}, o.getValues());
+                    case 4 -> assertArrayEquals(new String[] {"y"}, o.getValues());
+                    case 5 -> assertArrayEquals(new String[] {"z", "3"}, o.getValues());
+                    default -> fail("Didn't expect " + defineOptionsFound + " occurrences of -D");
                 }
             }
         }

--- a/src/test/java/org/apache/commons/cli/bug/BugsTest.java
+++ b/src/test/java/org/apache/commons/cli/bug/BugsTest.java
@@ -111,17 +111,16 @@ public class BugsTest {
         while (iter.hasNext()) {
             final Option opt = iter.next();
             switch (opt.getId()) {
-            case 'D':
-                assertEquals(opt.getValue(0), "JAVA_HOME");
-                assertEquals(opt.getValue(1), "/opt/java");
-                break;
-            case 'p':
-                assertEquals(opt.getValue(0), "file1");
-                assertEquals(opt.getValue(1), "file2");
-                assertEquals(opt.getValue(2), "file3");
-                break;
-            default:
-                fail("-D option not found");
+                case 'D' -> {
+                    assertEquals(opt.getValue(0), "JAVA_HOME");
+                    assertEquals(opt.getValue(1), "/opt/java");
+                }
+                case 'p' -> {
+                    assertEquals(opt.getValue(0), "file1");
+                    assertEquals(opt.getValue(1), "file2");
+                    assertEquals(opt.getValue(2), "file3");
+                }
+                default -> fail("-D option not found");
             }
         }
     }
@@ -345,5 +344,4 @@ public class BugsTest {
         assertTrue(cl.hasOption('o'));
         assertEquals("ovalue", cl.getOptionValue('o'));
     }
-
 }

--- a/src/test/java/org/apache/commons/cli/example/AptHelpAppendable.java
+++ b/src/test/java/org/apache/commons/cli/example/AptHelpAppendable.java
@@ -104,17 +104,12 @@ public class AptHelpAppendable extends FilterHelpAppendable {
                 final String header = table.headers().get(i);
                 final TextStyle style = table.columnTextStyles().get(i);
                 sb.append(StringUtils.repeat('-', header.length() + 2));
-                switch (style.getAlignment()) {
-                case LEFT:
-                    sb.append("+");
-                    break;
-                case CENTER:
-                    sb.append("*");
-                    break;
-                case RIGHT:
-                    sb.append(":");
-                    break;
-                }
+                String appendChar = switch (style.getAlignment()) {
+                    case LEFT -> "+";
+                    case CENTER -> "*";
+                    case RIGHT -> ":";
+                };
+                sb.append(appendChar);
             }
             final String rowSeparator = System.lineSeparator() + sb.append(System.lineSeparator());
             // output the header line.

--- a/src/test/java/org/apache/commons/cli/help/UtilTest.java
+++ b/src/test/java/org/apache/commons/cli/help/UtilTest.java
@@ -49,10 +49,10 @@ public class UtilTest {
         // @formatter:on
         final char[] nonBreakingSpace = { '\u00A0', '\u2007', '\u202F' };
         for (final char c : whitespace) {
-            lst.add(Arguments.of(Character.valueOf(c), Boolean.TRUE));
+            lst.add(Arguments.of(Character.valueOf(c), true));
         }
         for (final char c : nonBreakingSpace) {
-            lst.add(Arguments.of(Character.valueOf(c), Boolean.FALSE));
+            lst.add(Arguments.of(Character.valueOf(c), false));
         }
         return lst.stream();
     }


### PR DESCRIPTION
This commit migrates the package to the latest Java, and follows the new syntax. It also removes deprecated structures, e.g:
- URL constructor
- Character, Integer, Long constructor
    
The other changes involve:
- Switch new syntax
- Multi-line strings