### PR TITLE
Add new options for parsing: ignore and skip

### DIFF
--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -582,8 +582,9 @@ public class DefaultParser implements CommandLineParser {
      * the remaining tokens are added as-is in the arguments of the command line.
      *
      * @param token the command line token to handle
+     * @throws ParseException if parsing should fail
      */
-    private void handleUnknownToken(final String token) throws ParseException {
+    protected void handleUnknownToken(final String token) throws ParseException {
         if (token.startsWith("-") && token.length() > 1 && !stopAtNonOption) {
             throw new UnrecognizedOptionException("Unrecognized option: " + token, token);
         }

--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -732,7 +732,7 @@ public class DefaultParser implements CommandLineParser {
     }
 
     /**
-     * @see #parse(Options, String[], Properties, NonOptionAction)
+     * @see #parse(Options, Properties, NonOptionAction, String[])
      */
     @Override
     public CommandLine parse(final Options options, final String[] arguments, final boolean stopAtNonOption) throws ParseException {
@@ -764,26 +764,26 @@ public class DefaultParser implements CommandLineParser {
      *
      * @return the list of atomic option and value tokens
      * @throws ParseException if there are any problems encountered while parsing the command line tokens.
-     * @see #parse(Options, String[], Properties, NonOptionAction)
+     * @see #parse(Options, Properties, NonOptionAction, String[])
      */
     public CommandLine parse(final Options options, final String[] arguments, final Properties properties, final boolean stopAtNonOption)
         throws ParseException {
-        return parse(options, arguments, properties, stopAtNonOption ? NonOptionAction.STOP : NonOptionAction.THROW);
+        return parse(options, properties, stopAtNonOption ? NonOptionAction.STOP : NonOptionAction.THROW, arguments);
     }
 
     /**
      * Parses the arguments according to the specified options and properties.
      *
      * @param options the specified Options
-     * @param arguments the command line arguments
      * @param properties command line option name-value pairs
      * @param nonOptionAction see {@link NonOptionAction}.
+     * @param arguments the command line arguments
      *
      * @return the list of atomic option and value tokens
      * @throws ParseException if there are any problems encountered while parsing the command line tokens.
      * @since 1.10.0
      */
-    public CommandLine parse(final Options options, final String[] arguments, final Properties properties, final NonOptionAction nonOptionAction)
+    public CommandLine parse(final Options options, final Properties properties, final NonOptionAction nonOptionAction, final String... arguments)
             throws ParseException {
         this.options = options;
         this.nonOptionAction = nonOptionAction;

--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -175,10 +175,18 @@ public class DefaultParser implements CommandLineParser {
     protected Options options;
 
     /**
-     * Flag indicating how unrecognized tokens are handled. {@code true} to stop the parsing and add the remaining
-     * tokens to the args list. {@code false} to throw an exception.
+     * Flag indicating how unrecognized tokens are handled: {@code true} to stop the parsing and add the remaining
+     * tokens to the args list. {@code false} add current token to the arg list and continue parsing.
      */
     protected boolean stopAtNonOption;
+
+    /**
+     * Flag indicating how unrecognized tokens are handled: {@code true} to abort parsing by throwing {@link ParseException}.
+     * {@code false} to ignore it.
+     *
+     * @since 1.10.0
+     */
+    protected boolean throwAtNonOption = true;
 
     /** The token currently processed. */
     protected String currentToken;
@@ -583,9 +591,10 @@ public class DefaultParser implements CommandLineParser {
      *
      * @param token the command line token to handle
      * @throws ParseException if parsing should fail
+     * @since 1.10.0
      */
     protected void handleUnknownToken(final String token) throws ParseException {
-        if (token.startsWith("-") && token.length() > 1 && !stopAtNonOption) {
+        if (token.startsWith("-") && token.length() > 1 && throwAtNonOption) {
             throw new UnrecognizedOptionException("Unrecognized option: " + token, token);
         }
         addArg(token);
@@ -692,6 +701,9 @@ public class DefaultParser implements CommandLineParser {
         return parse(options, arguments, null);
     }
 
+    /**
+     * @see #parse(Options, String[], Properties, boolean, boolean)
+     */
     @Override
     public CommandLine parse(final Options options, final String[] arguments, final boolean stopAtNonOption) throws ParseException {
         return parse(options, arguments, null, stopAtNonOption);
@@ -722,11 +734,31 @@ public class DefaultParser implements CommandLineParser {
      *
      * @return the list of atomic option and value tokens
      * @throws ParseException if there are any problems encountered while parsing the command line tokens.
+     * @see #parse(Options, String[], Properties, boolean, boolean)
      */
     public CommandLine parse(final Options options, final String[] arguments, final Properties properties, final boolean stopAtNonOption)
         throws ParseException {
+        return parse(options, arguments, properties, stopAtNonOption, !stopAtNonOption);
+    }
+
+    /**
+     * Parses the arguments according to the specified options and properties.
+     *
+     * @param options the specified Options
+     * @param arguments the command line arguments
+     * @param properties command line option name-value pairs
+     * @param stopAtNonOption see {@link #stopAtNonOption}.
+     * @param throwAtNonOption see {@link #throwAtNonOption}.
+     *
+     * @return the list of atomic option and value tokens
+     * @throws ParseException if there are any problems encountered while parsing the command line tokens.
+     * @since 1.10.0
+     */
+    public CommandLine parse(final Options options, final String[] arguments, final Properties properties, final boolean stopAtNonOption,
+                             final boolean throwAtNonOption) throws ParseException {
         this.options = options;
         this.stopAtNonOption = stopAtNonOption;
+        this.throwAtNonOption = throwAtNonOption;
         skipParsing = false;
         currentOption = null;
         expectedOpts = new ArrayList<>(options.getRequiredOptions());

--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -558,7 +558,7 @@ public class DefaultParser implements CommandLineParser {
         if (token != null) {
             currentToken = token;
             if (skipParsing) {
-                cmd.addArg(token);
+                addArg(token);
             } else if ("--".equals(token)) {
                 skipParsing = true;
             } else if (currentOption != null && currentOption.acceptsArg() && isArgument(token)) {
@@ -588,10 +588,20 @@ public class DefaultParser implements CommandLineParser {
         if (token.startsWith("-") && token.length() > 1 && !stopAtNonOption) {
             throw new UnrecognizedOptionException("Unrecognized option: " + token, token);
         }
-        cmd.addArg(token);
+        addArg(token);
         if (stopAtNonOption) {
             skipParsing = true;
         }
+    }
+
+    /**
+     * Adds token to command line {@link CommandLine#addArg(String)}.
+     *
+     * @param token the unrecognized option/argument.
+     * @since 1.10.0
+     */
+    protected void addArg(final String token) {
+        cmd.addArg(token);
     }
 
     /**

--- a/src/test/java/org/apache/commons/cli/DefaultParserTest.java
+++ b/src/test/java/org/apache/commons/cli/DefaultParserTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
@@ -155,6 +156,83 @@ class DefaultParserTest extends AbstractParserTestCase {
     public void setUp() {
         super.setUp();
         parser = new DefaultParser();
+    }
+
+    @Test
+    void chainingParsersHappyPath() throws ParseException {
+        Option a = Option.builder().option("a").longOpt("first-letter").build();
+        Option b = Option.builder().option("b").longOpt("second-letter").build();
+        Option c = Option.builder().option("c").longOpt("third-letter").build();
+        Option d = Option.builder().option("d").longOpt("fourth-letter").build();
+
+        Options baseOptions = new Options();
+        baseOptions.addOption(a);
+        baseOptions.addOption(b);
+        Options specificOptions = new Options();
+        specificOptions.addOption(a);
+        specificOptions.addOption(b);
+        specificOptions.addOption(c);
+        specificOptions.addOption(d);
+
+        String[] args = {"-a", "-b", "-c", "-d", "arg1", "arg2"};
+
+        DefaultParser parser = new DefaultParser();
+
+        CommandLine baseCommandLine = parser.parse(baseOptions, args, null, false, false);
+        assertEquals(2, baseCommandLine.getOptions().length);
+        assertEquals(4, baseCommandLine.getArgs().length);
+        assertTrue(baseCommandLine.hasOption("a"));
+        assertTrue(baseCommandLine.hasOption("b"));
+        assertFalse(baseCommandLine.hasOption("c"));
+        assertFalse(baseCommandLine.hasOption("d"));
+        assertFalse(baseCommandLine.getArgList().contains("-a"));
+        assertFalse(baseCommandLine.getArgList().contains("-b"));
+        assertTrue(baseCommandLine.getArgList().contains("-c"));
+        assertTrue(baseCommandLine.getArgList().contains("-d"));
+        assertTrue(baseCommandLine.getArgList().contains("arg1"));
+        assertTrue(baseCommandLine.getArgList().contains("arg2"));
+
+        CommandLine specificCommandLine = parser.parse(specificOptions, args, null, false, true);
+        assertEquals(4, specificCommandLine.getOptions().length);
+        assertEquals(2, specificCommandLine.getArgs().length);
+        assertTrue(specificCommandLine.hasOption("a"));
+        assertTrue(specificCommandLine.hasOption("b"));
+        assertTrue(specificCommandLine.hasOption("c"));
+        assertTrue(specificCommandLine.hasOption("d"));
+        assertFalse(specificCommandLine.getArgList().contains("-a"));
+        assertFalse(specificCommandLine.getArgList().contains("-b"));
+        assertFalse(specificCommandLine.getArgList().contains("-c"));
+        assertFalse(specificCommandLine.getArgList().contains("-d"));
+        assertTrue(specificCommandLine.getArgList().contains("arg1"));
+        assertTrue(specificCommandLine.getArgList().contains("arg2"));
+    }
+
+    @Test
+    void chainingParsersNonHappyPath() throws ParseException {
+        Option a = Option.builder().option("a").longOpt("first-letter").build();
+        Option b = Option.builder().option("b").longOpt("second-letter").build();
+        Option c = Option.builder().option("c").longOpt("third-letter").build();
+        Option d = Option.builder().option("d").longOpt("fourth-letter").build();
+
+        Options baseOptions = new Options();
+        baseOptions.addOption(a);
+        baseOptions.addOption(b);
+        Options specificOptions = new Options();
+        specificOptions.addOption(a);
+        specificOptions.addOption(b);
+        specificOptions.addOption(c);
+        specificOptions.addOption(d);
+
+        String[] args = {"-a", "-b", "-c", "-d", "arg1", "arg2", "--rogue-option"};
+
+        DefaultParser parser = new DefaultParser();
+
+        CommandLine baseCommandLine = parser.parse(baseOptions, args, null, false, false);
+        assertEquals(2, baseCommandLine.getOptions().length);
+        assertEquals(5, baseCommandLine.getArgs().length);
+
+        UnrecognizedOptionException e = assertThrows(UnrecognizedOptionException.class, () -> parser.parse(specificOptions, args, null, false, true));
+        assertTrue(e.getMessage().contains("--rogue-option"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/DefaultParserTest.java
+++ b/src/test/java/org/apache/commons/cli/DefaultParserTest.java
@@ -234,6 +234,33 @@ class DefaultParserTest extends AbstractParserTestCase {
     }
 
     @Test
+    void legacyStopAtNonOption() throws ParseException {
+        Option a = Option.builder().option("a").longOpt("first-letter").build();
+        Option b = Option.builder().option("b").longOpt("second-letter").build();
+        Option c = Option.builder().option("c").longOpt("third-letter").build();
+
+        Options options = new Options();
+        options.addOption(a);
+        options.addOption(b);
+        options.addOption(c);
+
+        String[] args = {"-a", "-b", "-c", "-d", "arg1", "arg2"}; // -d is rogue option
+
+        DefaultParser parser = new DefaultParser();
+
+        CommandLine commandLine = parser.parse(options, args, null, true);
+        assertEquals(3, commandLine.getOptions().length);
+        assertEquals(3, commandLine.getArgs().length);
+        assertFalse(commandLine.getArgList().contains("-c"));
+        assertTrue(commandLine.getArgList().contains("-d"));
+        assertTrue(commandLine.getArgList().contains("arg1"));
+        assertTrue(commandLine.getArgList().contains("arg2"));
+
+        UnrecognizedOptionException e = assertThrows(UnrecognizedOptionException.class, () -> parser.parse(options, args, null, false));
+        assertTrue(e.getMessage().contains("-d"));
+    }
+
+    @Test
     void testBuilder() {
         // @formatter:off
         final Builder builder = DefaultParser.builder()

--- a/src/test/java/org/apache/commons/cli/DefaultParserTest.java
+++ b/src/test/java/org/apache/commons/cli/DefaultParserTest.java
@@ -251,7 +251,6 @@ class DefaultParserTest extends AbstractParserTestCase {
         CommandLine commandLine = parser.parse(options, args, null, true);
         assertEquals(3, commandLine.getOptions().length);
         assertEquals(3, commandLine.getArgs().length);
-        assertFalse(commandLine.getArgList().contains("-c"));
         assertTrue(commandLine.getArgList().contains("-d"));
         assertTrue(commandLine.getArgList().contains("arg1"));
         assertTrue(commandLine.getArgList().contains("arg2"));

--- a/src/test/java/org/apache/commons/cli/DefaultParserTest.java
+++ b/src/test/java/org/apache/commons/cli/DefaultParserTest.java
@@ -178,7 +178,7 @@ class DefaultParserTest extends AbstractParserTestCase {
 
         DefaultParser parser = new DefaultParser();
 
-        CommandLine baseCommandLine = parser.parse(baseOptions, args, null, DefaultParser.NonOptionAction.SKIP);
+        CommandLine baseCommandLine = parser.parse(baseOptions, null, DefaultParser.NonOptionAction.SKIP, args);
         assertEquals(2, baseCommandLine.getOptions().length);
         assertEquals(4, baseCommandLine.getArgs().length);
         assertTrue(baseCommandLine.hasOption("a"));
@@ -192,7 +192,7 @@ class DefaultParserTest extends AbstractParserTestCase {
         assertTrue(baseCommandLine.getArgList().contains("arg1"));
         assertTrue(baseCommandLine.getArgList().contains("arg2"));
 
-        CommandLine specificCommandLine = parser.parse(specificOptions, args, null, DefaultParser.NonOptionAction.THROW);
+        CommandLine specificCommandLine = parser.parse(specificOptions, null, DefaultParser.NonOptionAction.THROW, args);
         assertEquals(4, specificCommandLine.getOptions().length);
         assertEquals(2, specificCommandLine.getArgs().length);
         assertTrue(specificCommandLine.hasOption("a"));
@@ -225,12 +225,12 @@ class DefaultParserTest extends AbstractParserTestCase {
 
         DefaultParser parser = new DefaultParser();
 
-        CommandLine baseCommandLine = parser.parse(baseOptions, args, null, DefaultParser.NonOptionAction.SKIP);
+        CommandLine baseCommandLine = parser.parse(baseOptions, null, DefaultParser.NonOptionAction.SKIP, args);
         assertEquals(2, baseCommandLine.getOptions().length);
         assertEquals(4, baseCommandLine.getArgs().length);
 
         UnrecognizedOptionException e = assertThrows(UnrecognizedOptionException.class,
-                () -> parser.parse(specificOptions, args, null, DefaultParser.NonOptionAction.THROW));
+                () -> parser.parse(specificOptions, null, DefaultParser.NonOptionAction.THROW, args));
         assertTrue(e.getMessage().contains("-d"));
     }
 
@@ -254,7 +254,7 @@ class DefaultParserTest extends AbstractParserTestCase {
 
         DefaultParser parser = new DefaultParser();
 
-        CommandLine baseCommandLine = parser.parse(baseOptions, args, null, DefaultParser.NonOptionAction.IGNORE);
+        CommandLine baseCommandLine = parser.parse(baseOptions, null, DefaultParser.NonOptionAction.IGNORE, args);
         assertEquals(2, baseCommandLine.getOptions().length);
         assertEquals(2, baseCommandLine.getArgs().length);
         assertTrue(baseCommandLine.hasOption("a"));
@@ -268,7 +268,7 @@ class DefaultParserTest extends AbstractParserTestCase {
         assertTrue(baseCommandLine.getArgList().contains("arg1"));
         assertTrue(baseCommandLine.getArgList().contains("arg2"));
 
-        CommandLine specificCommandLine = parser.parse(specificOptions, args, null, DefaultParser.NonOptionAction.THROW);
+        CommandLine specificCommandLine = parser.parse(specificOptions, null, DefaultParser.NonOptionAction.THROW, args);
         assertEquals(4, specificCommandLine.getOptions().length);
         assertEquals(2, specificCommandLine.getArgs().length);
         assertTrue(specificCommandLine.hasOption("a"));
@@ -301,12 +301,12 @@ class DefaultParserTest extends AbstractParserTestCase {
 
         DefaultParser parser = new DefaultParser();
 
-        CommandLine baseCommandLine = parser.parse(baseOptions, args, null, DefaultParser.NonOptionAction.IGNORE);
+        CommandLine baseCommandLine = parser.parse(baseOptions, null, DefaultParser.NonOptionAction.IGNORE, args);
         assertEquals(2, baseCommandLine.getOptions().length);
         assertEquals(2, baseCommandLine.getArgs().length);
 
         UnrecognizedOptionException e = assertThrows(UnrecognizedOptionException.class,
-                () -> parser.parse(specificOptions, args, null, DefaultParser.NonOptionAction.THROW));
+                () -> parser.parse(specificOptions, null, DefaultParser.NonOptionAction.THROW, args));
         assertTrue(e.getMessage().contains("-d"));
     }
 

--- a/src/test/java/org/apache/commons/cli/DefaultParserTest.java
+++ b/src/test/java/org/apache/commons/cli/DefaultParserTest.java
@@ -212,7 +212,6 @@ class DefaultParserTest extends AbstractParserTestCase {
         Option a = Option.builder().option("a").longOpt("first-letter").build();
         Option b = Option.builder().option("b").longOpt("second-letter").build();
         Option c = Option.builder().option("c").longOpt("third-letter").build();
-        Option d = Option.builder().option("d").longOpt("fourth-letter").build();
 
         Options baseOptions = new Options();
         baseOptions.addOption(a);
@@ -221,18 +220,17 @@ class DefaultParserTest extends AbstractParserTestCase {
         specificOptions.addOption(a);
         specificOptions.addOption(b);
         specificOptions.addOption(c);
-        specificOptions.addOption(d);
 
-        String[] args = {"-a", "-b", "-c", "-d", "arg1", "arg2", "--rogue-option"};
+        String[] args = {"-a", "-b", "-c", "-d", "arg1", "arg2"}; // -d is rogue option
 
         DefaultParser parser = new DefaultParser();
 
         CommandLine baseCommandLine = parser.parse(baseOptions, args, null, false, false);
         assertEquals(2, baseCommandLine.getOptions().length);
-        assertEquals(5, baseCommandLine.getArgs().length);
+        assertEquals(4, baseCommandLine.getArgs().length);
 
         UnrecognizedOptionException e = assertThrows(UnrecognizedOptionException.class, () -> parser.parse(specificOptions, args, null, false, true));
-        assertTrue(e.getMessage().contains("--rogue-option"));
+        assertTrue(e.getMessage().contains("-d"));
     }
 
     @Test


### PR DESCRIPTION
Goal is to introduce new "ops" for CLI parser: a mode when unknown options are completely ignored or just skipped (added to args). At the same time encapsulation is loosened as well, by making relevant methods `protected` to allow possible override/extension of `DefaultParser` class.

---

Simpler variation of #378

Goal: to "postpone" full argument parsing. To be used in Maven. We introduced new "cli commands" aside of existing `mvn`, like `mvnenc`, `mvnsh` and `mvnup`. 

The "base" options (all CLI command) are these:
https://github.com/apache/maven/blob/77ebd14d1580e0a67c5a929afdd3ac62a3bfea1f/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/Options.java

And each command _extends_ this base with specific options, for example:
https://github.com/apache/maven/blob/77ebd14d1580e0a67c5a929afdd3ac62a3bfea1f/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvn/MavenOptions.java
https://github.com/apache/maven/blob/77ebd14d1580e0a67c5a929afdd3ac62a3bfea1f/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvnenc/EncryptOptions.java
https://github.com/apache/maven/blob/77ebd14d1580e0a67c5a929afdd3ac62a3bfea1f/api/maven-api-cli/src/main/java/org/apache/maven/api/cli/mvnup/UpgradeOptions.java

Now the goal would be to _move_ these commands (currently "burned into Maven core") _into dynamically resolved extensions_. Original idea is to "boot Maven DI base", figure out which command extension is wanted, and then once given "tool" loaded, have it parse the "remainder" specific arguments (that are unknown and start, the options depend on the tool being loaded).

tl;dr: we want to be able to parse "common" base set of options, that are same across multiple commands, then load command dynamically (Maven would resolve and load it into DI like any other extension), and then let the loaded command parse the "remainder" (own specific subset) or arguments.

tl;dr more short: to be able to "chain" arg parsing from "generic" to more "specific" (and unknown which specific at start).