### PR TITLE
Reject non-BMP code points in the Character type converter

### DIFF
--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -230,7 +230,16 @@ public class TypeHandler {
         map.put(Integer.class, Integer::parseInt);
         map.put(Short.class, Short::parseShort);
         map.put(Byte.class, Byte::parseByte);
-        map.put(Character.class, s -> s.startsWith("\\u") ? Character.toChars(Integer.parseInt(s.substring(2), HEX_RADIX))[0] : s.charAt(0));
+        map.put(Character.class, s -> {
+            if (s.startsWith("\\u")) {
+                final int codePoint = Integer.parseInt(s.substring(2), HEX_RADIX);
+                if (!Character.isBmpCodePoint(codePoint)) {
+                    throw new IllegalArgumentException("Code point U+" + Integer.toHexString(codePoint) + " does not fit in a char");
+                }
+                return (char) codePoint;
+            }
+            return s.charAt(0);
+        });
         map.put(Double.class, Double::parseDouble);
         map.put(Float.class, Float::parseFloat);
         map.put(BigInteger.class, BigInteger::new);

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -134,6 +134,7 @@ class TypeHandlerTest {
         list.add(Arguments.of("5", Character.class, '5'));
         list.add(Arguments.of("5.5", Character.class, '5'));
         list.add(Arguments.of("\\u0124", Character.class, Character.toChars(0x0124)[0]));
+        list.add(Arguments.of("\\u1F600", Character.class, ParseException.class));
 
         list.add(Arguments.of("just-a-string", Double.class, ParseException.class));
         list.add(Arguments.of("5", Double.class, 5d));


### PR DESCRIPTION
1. the Character converter parses a \uXXXX escape and returns Character.toChars(codePoint)[0], so a supplementary code point like \u1F600 silently becomes the lone high surrogate U+D83D.
2. that half surrogate is an invalid char and gets lost downstream (it round-trips to '?' through UTF-8).

Checked the code point is in the BMP before the cast and throw otherwise, so the value is rejected at conversion instead of quietly truncated. Have we considered that a char simply cannot hold an astral code point? Added a parameterized case for \u1F600 next to the existing \u0124 one.