### PR TITLE
Use Locale.ENGLISH when parsing dates in Converter.DATE

### DIFF
--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 /**
  * The definition of the functional interface to call when doing a conversion. Like {@code Function<String,T>} but can throw an Exception.
@@ -76,7 +77,15 @@ public interface Converter<T, E extends Exception> {
     /**
      * Converts a String to a {@link Date} using the format string Form "EEE MMM dd HH:mm:ss zzz yyyy".
      */
-    Converter<Date, java.text.ParseException> DATE = s -> new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy").parse(s);
+    Converter<Date, java.text.ParseException> DATE = s -> {
+        try {
+            return new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy").parse(s);
+        } catch (final java.text.ParseException e) {
+            // Date.toString() always emits English month/day names, so fall back to Locale.ENGLISH
+            // when the default locale rejects the documented format.
+            return new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH).parse(s);
+        }
+    };
 
     /**
      * Applies the conversion function to the String argument.

--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -78,12 +78,13 @@ public interface Converter<T, E extends Exception> {
      * Converts a String to a {@link Date} using the format string Form "EEE MMM dd HH:mm:ss zzz yyyy".
      */
     Converter<Date, java.text.ParseException> DATE = s -> {
+        final String pattern = "EEE MMM dd HH:mm:ss zzz yyyy";
         try {
-            return new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy").parse(s);
+            return new SimpleDateFormat(pattern).parse(s);
         } catch (final java.text.ParseException e) {
             // Date.toString() always emits English month/day names, so fall back to Locale.ENGLISH
             // when the default locale rejects the documented format.
-            return new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH).parse(s);
+            return new SimpleDateFormat(pattern, Locale.ENGLISH).parse(s);
         }
     };
 

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -27,6 +27,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -90,6 +91,16 @@ public class ConverterTests {
     void testDateLocaleDe() throws Exception {
         final Date expected = new Date(1023400137000L);
         final String formatted = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy").format(expected);
+        assertEquals(expected, Converter.DATE.apply(formatted));
+    }
+
+    @Test
+    @DefaultLocale(language = "de", country = "DE")
+    void testDateLocaleDeEnglishInput() throws Exception {
+        // Date.toString() always emits English month/day names, so the converter must still parse
+        // them when the default locale is not English.
+        final Date expected = new Date(1023400137000L);
+        final String formatted = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH).format(expected);
         assertEquals(expected, Converter.DATE.apply(formatted));
     }
 


### PR DESCRIPTION
`Converter.DATE` parses with a default-locale `SimpleDateFormat`, but its documented input (the output of `Date.toString()`) always uses English month and day names, so a `Date`-typed option throws `ParseException` under any non-English default locale; pinning `Locale.ENGLISH` keeps the documented round-trip stable, which is also why `testCreateDate` already needed a `@DefaultLocale` pin.