### PR TITLE
Refactor DefaultParser, Option, and Options for improved maintainabilityRefactor/code smells

### DIFF
--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -546,63 +546,84 @@ public class DefaultParser implements CommandLineParser {
     private void handleShortAndLongOption(final String hyphenToken) throws ParseException {
         final String token = Util.stripLeadingHyphens(hyphenToken);
         final int pos = indexOfEqual(token);
+
         if (token.length() == 1) {
-            // -S
-            if (options.hasShortOption(token)) {
-                handleOption(options.getOption(token));
-            } else {
-                handleUnknownToken(hyphenToken);
-            }
+            handleSingleOption(token, hyphenToken);
         } else if (pos == -1) {
-            // no equal sign found (-xxx)
-            if (options.hasShortOption(token)) {
-                handleOption(options.getOption(token));
-            } else if (!getMatchingLongOptions(token).isEmpty()) {
-                // -L or -l
-                handleLongOptionWithoutEqual(hyphenToken);
-            } else {
-                // look for a long prefix (-Xmx512m)
-                final String opt = getLongPrefix(token);
-
-                if (opt != null && options.getOption(opt).acceptsArg()) {
-                    handleOption(options.getOption(opt));
-                    currentOption.processValue(stripLeadingAndTrailingQuotesDefaultOff(token.substring(opt.length())));
-                    currentOption = null;
-                } else if (isJavaProperty(token)) {
-                    // -SV1 (-Dflag)
-                    handleOption(options.getOption(token.substring(0, 1)));
-                    currentOption.processValue(stripLeadingAndTrailingQuotesDefaultOff(token.substring(1)));
-                    currentOption = null;
-                } else {
-                    // -S1S2S3 or -S1S2V
-                    handleConcatenatedOptions(hyphenToken);
-                }
-            }
+            handleOptionWithoutEqual(token, hyphenToken);
         } else {
-            // equal sign found (-xxx=yyy)
-            final String opt = token.substring(0, pos);
-            final String value = token.substring(pos + 1);
+            handleOptionWithEqual(token, hyphenToken, pos);
+        }
+    }
+    private void handleSingleOption(final String token, final String hyphenToken)
+            throws ParseException {
 
-            if (opt.length() == 1) {
-                // -S=V
-                final Option option = options.getOption(opt);
-                if (option != null && option.acceptsArg()) {
-                    handleOption(option);
-                    currentOption.processValue(value);
-                    currentOption = null;
-                } else {
-                    handleUnknownToken(hyphenToken);
-                }
-            } else if (isJavaProperty(opt)) {
-                // -SV1=V2 (-Dkey=value)
-                handleOption(options.getOption(opt.substring(0, 1)));
-                currentOption.processValue(opt.substring(1));
+        if (options.hasShortOption(token)) {
+            handleOption(options.getOption(token));
+        } else {
+            handleUnknownToken(hyphenToken);
+        }
+    }
+      private void handleOptionWithoutEqual(final String token,
+                                      final String hyphenToken)
+        throws ParseException {
+
+    if (options.hasShortOption(token)) {
+        handleOption(options.getOption(token));
+    } else if (!getMatchingLongOptions(token).isEmpty()) {
+        // -L or -l
+        handleLongOptionWithoutEqual(hyphenToken);
+    } else {
+        // look for a long prefix (-Xmx512m)
+        final String opt = getLongPrefix(token);
+
+        if (opt != null && options.getOption(opt).acceptsArg()) {
+            handleOption(options.getOption(opt));
+            currentOption.processValue(
+                    stripLeadingAndTrailingQuotesDefaultOff(token.substring(opt.length())));
+            currentOption = null;
+        } else if (isJavaProperty(token)) {
+            // -SV1 (-Dflag)
+            handleOption(options.getOption(token.substring(0, 1)));
+            currentOption.processValue(
+                    stripLeadingAndTrailingQuotesDefaultOff(token.substring(1)));
+            currentOption = null;
+        } else {
+            // -S1S2S3 or -S1S2V
+            handleConcatenatedOptions(hyphenToken);
+        }
+    }
+}
+    private void handleOptionWithEqual(final String token,
+                                       final String hyphenToken,
+                                       final int pos)
+            throws ParseException {
+
+        final String opt = token.substring(0, pos);
+        final String value = token.substring(pos + 1);
+
+        if (opt.length() == 1) {
+            final Option option = options.getOption(opt);
+
+            if (option != null && option.acceptsArg()) {
+                handleOption(option);
                 currentOption.processValue(value);
                 currentOption = null;
             } else {
-                // -L=V or -l=V
-                handleLongOptionWithEqual(hyphenToken);
+                handleUnknownToken(hyphenToken);
             }
+
+        } else if (isJavaProperty(opt)) {
+
+            handleOption(options.getOption(opt.substring(0, 1)));
+            currentOption.processValue(opt.substring(1));
+            currentOption.processValue(value);
+            currentOption = null;
+
+        } else {
+
+            handleLongOptionWithEqual(hyphenToken);
+
         }
     }
 

--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -845,31 +845,36 @@ public class Option implements Cloneable, Serializable {
         if (argCount == UNINITIALIZED) {
             throw new IllegalStateException("NO_ARGS_ALLOWED");
         }
+
         String add = Objects.requireNonNull(value, "value");
-        // this Option has a separator character
+
         if (hasValueSeparator()) {
-            // get the separator character
-            final char sep = getValueSeparator();
-            // store the index for the value separator
-            int index = add.indexOf(sep);
-            // while there are more value separators
-            while (index != -1) {
-                // next value to be added
-                if (values.size() == argCount - 1) {
-                    break;
-                }
-                // store
-                add(add.substring(0, index));
-                // parse
-                add = add.substring(index + 1);
-                // get new index
-                index = add.indexOf(sep);
-            }
+            add = processSeparatedValues(add);
         }
-        // store the actual value or the last value that has been parsed
+
         add(add);
     }
+    private String processSeparatedValues(String value) {
 
+        final char separator = getValueSeparator();
+
+        int index = value.indexOf(separator);
+
+        while (index != -1) {
+
+            if (values.size() == argCount - 1) {
+                break;
+            }
+
+            add(value.substring(0, index));
+
+            value = value.substring(index + 1);
+
+            index = value.indexOf(separator);
+        }
+
+        return value;
+    }
     /**
      * Tests whether the option requires more arguments to be valid.
      *

--- a/src/main/java/org/apache/commons/cli/Options.java
+++ b/src/main/java/org/apache/commons/cli/Options.java
@@ -78,9 +78,7 @@ public class Options implements Serializable {
         }
         // if the option is required add it to the required list
         if (opt.isRequired()) {
-            if (requiredOpts.contains(key)) {
-                requiredOpts.remove(requiredOpts.indexOf(key));
-            }
+            requiredOpts.remove(key);
             requiredOpts.add(key);
         }
         shortOpts.put(key, opt);
@@ -265,8 +263,8 @@ public class Options implements Serializable {
 
         // The optionGroups map will have duplicates in the values() results. We
         // use the HashSet to filter out duplicates and return a collection of
-        // OpitonGroup. The decision to return a Collection rather than a set
-        // was probably to keep symmetry with the getOptions() method.
+        // OptionGroup. A Collection (not a Set) is returned to keep symmetry
+        // with the getOptions() method's return type.
         return new HashSet<>(optionGroups.values());
     }
 
@@ -336,14 +334,10 @@ public class Options implements Serializable {
      *
      * @return Stringified form of this object.
      */
+
     @Override
     public String toString() {
-        final StringBuilder buf = new StringBuilder();
-        buf.append("[ Options: [ short ");
-        buf.append(shortOpts.toString());
-        buf.append(" ] [ long ");
-        buf.append(longOpts);
-        buf.append(" ]");
-        return buf.toString();
+        return "[ Options: [ short " + shortOpts + " ] [ long " + longOpts + " ]";
+
     }
 }


### PR DESCRIPTION
## Summary

This pull request improves the maintainability of Apache Commons CLI by applying several small refactorings without changing the external behavior.

## Refactorings

### 1. DefaultParser

- Applied Extract Method to reduce cognitive complexity.
- Split the large `handleShortAndLongOption()` method into smaller helper methods.

### 2. Option

- Refactored `processValue()`.
- Extracted separator parsing logic into a dedicated helper method.
- Improved readability and separation of responsibilities.

### 3. Options

- Simplified required option update logic.
- Removed redundant lookup operations by replacing `contains()` + `indexOf()` with a single `remove(Object)` call.

## Validation

- Project builds successfully.
- All existing tests pass (`mvn test`).
- No functional behavior has changed.

## Benefits

- Improved readability
- Better maintainability
- Reduced cognitive complexity
- Cleaner collection handling