### PR TITLE
Reject invalid dates in Converter.DATE

### DIFF
--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -79,12 +79,17 @@ public interface Converter<T, E extends Exception> {
      */
     Converter<Date, java.text.ParseException> DATE = s -> {
         final String pattern = "EEE MMM dd HH:mm:ss zzz yyyy";
+        final SimpleDateFormat format = new SimpleDateFormat(pattern);
+        // reject out-of-range fields (for example "Feb 30") instead of silently rolling them over.
+        format.setLenient(false);
         try {
-            return new SimpleDateFormat(pattern).parse(s);
+            return format.parse(s);
         } catch (final java.text.ParseException e) {
             // Date.toString() always emits English month/day names, so fall back to Locale.ENGLISH
             // when the default locale rejects the documented format.
-            return new SimpleDateFormat(pattern, Locale.ENGLISH).parse(s);
+            final SimpleDateFormat englishFormat = new SimpleDateFormat(pattern, Locale.ENGLISH);
+            englishFormat.setLenient(false);
+            return englishFormat.parse(s);
         }
     };
 

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -105,6 +105,14 @@ public class ConverterTests {
     }
 
     @Test
+    void testDateRejectsInvalid() {
+        // A lenient SimpleDateFormat rolls "Feb 30" over to March 1; the converter must reject
+        // out-of-range fields instead of silently returning a wrong Date.
+        assertThrows(java.text.ParseException.class, () -> Converter.DATE.apply("Fri Feb 30 12:00:00 UTC 2024"));
+        assertThrows(java.text.ParseException.class, () -> Converter.DATE.apply("Mon Jan 32 00:00:00 UTC 2024"));
+    }
+
+    @Test
     void testFile() throws Exception {
         final URL url = this.getClass().getClassLoader().getResource("./org/apache/commons/cli/existing-readable.file");
         final String fileName = url.toString().substring("file:".length());


### PR DESCRIPTION
`Converter.DATE` parses with a lenient `SimpleDateFormat`, so an impossible date like `Fri Feb 30 ...` is silently rolled over to a wrong `Date` instead of rejected; `setLenient(false)` rejects out-of-range fields while every valid `Date.toString()` value still parses.