### PR TITLE
Reject hex-float and suffixed values in Converter.NUMBER

### DIFF
--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -17,6 +17,7 @@
 package org.apache.commons.cli;
 
 import java.io.File;
+import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.InvalidPathException;
@@ -60,7 +61,16 @@ public interface Converter<T, E extends Exception> {
     /**
      * Converts a String to a {@link Number}. Converts to a Double if a decimal point ('.') is in the string or a Long otherwise.
      */
-    Converter<Number, NumberFormatException> NUMBER = s -> s.indexOf('.') != -1 ? (Number) Double.valueOf(s) : (Number) Long.valueOf(s);
+    Converter<Number, NumberFormatException> NUMBER = s -> {
+        if (s.indexOf('.') != -1) {
+            // Double.valueOf() also accepts hexadecimal floating point (0x1.8p1), type suffixes (1.0d, 1.0f)
+            // and surrounding whitespace; validate with a strict BigDecimal parse so those are rejected like
+            // the Long branch already rejects them.
+            new BigDecimal(s);
+            return Double.valueOf(s);
+        }
+        return Long.valueOf(s);
+    };
 
     /**
      * Converts a class name to an instance of the class. Uses the Class converter to find the class and then call the default constructor.

--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -64,10 +64,8 @@ public interface Converter<T, E extends Exception> {
     Converter<Number, NumberFormatException> NUMBER = s -> {
         if (s.indexOf('.') != -1) {
             // Double.valueOf() also accepts hexadecimal floating point (0x1.8p1), type suffixes (1.0d, 1.0f)
-            // and surrounding whitespace; validate with a strict BigDecimal parse so those are rejected like
-            // the Long branch already rejects them.
-            new BigDecimal(s);
-            return Double.valueOf(s);
+            // and surrounding whitespace; a strict BigDecimal parse rejects those like the Long branch already does.
+            return new BigDecimal(s).doubleValue();
         }
         return Long.valueOf(s);
     };

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -56,9 +56,15 @@ public class ConverterTests {
         lst.add(Arguments.of("-12.3", Double.valueOf("-12.3")));
         lst.add(Arguments.of(".3", Double.valueOf("0.3")));
         lst.add(Arguments.of("-.3", Double.valueOf("-0.3")));
+        lst.add(Arguments.of("1.2e3", Double.valueOf("1.2e3")));
         lst.add(Arguments.of("0x5F", null));
         lst.add(Arguments.of("2,3", null));
         lst.add(Arguments.of("1.2.3", null));
+        // Double.valueOf() accepts these, but a decimal number does not; the Long branch already rejects the same junk.
+        lst.add(Arguments.of("1.0d", null));
+        lst.add(Arguments.of("1.0f", null));
+        lst.add(Arguments.of("0x1.8p1", null));
+        lst.add(Arguments.of(" 1.2 ", null));
         return lst.stream();
     }
 


### PR DESCRIPTION
`NUMBER` routes any value containing `.` to `Double.valueOf`, which also accepts hexadecimal floating point (`0x1.8p1`), type suffixes (`1.0d`, `1.0f`) and surrounding whitespace, so a strict `BigDecimal` parse now rejects those the way the integer branch already does.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
