### PR TITLE
Load classes without initializing them in Converter.CLASS

### DIFF
--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -43,9 +43,10 @@ public interface Converter<T, E extends Exception> {
     Converter<?, RuntimeException> DEFAULT = s -> s;
 
     /**
-     * Converts a String to a {@link Class}. Calls {@link Class#forName(String)}.
+     * Converts a String to a {@link Class}. Calls {@link Class#forName(String, boolean, ClassLoader)} with {@code initialize} set to {@code false} so that
+     * naming a class does not run its static initializer.
      */
-    Converter<Class<?>, ClassNotFoundException> CLASS = Class::forName;
+    Converter<Class<?>, ClassNotFoundException> CLASS = s -> Class.forName(s, false, Converter.class.getClassLoader());
 
     /**
      * Converts a String to a {@link File}. Calls {@link File#File(String)}.

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -18,8 +18,10 @@
 package org.apache.commons.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
 import java.text.DateFormat;
@@ -41,12 +43,23 @@ import org.junitpioneer.jupiter.DefaultLocale;
  */
 public class ConverterTests {
 
+    // A class whose static initializer has an observable side effect.
+    public static class AClassWithAStaticInitializer {
+
+        static {
+            classInitializerRan = true;
+        }
+    }
+
     // A class without a default constructor.
     public class AClassWithoutADefaultConstructor {
 
         public AClassWithoutADefaultConstructor(final int i) {
         }
     }
+
+    // Set by the static initializer of AClassWithAStaticInitializer; readable without initializing that class.
+    private static boolean classInitializerRan;
 
     private static Stream<Arguments> numberTestParameters() {
         final List<Arguments> lst = new ArrayList<>();
@@ -70,6 +83,15 @@ public class ConverterTests {
         assertNotNull(Converter.CLASS.apply(this.getClass().getTypeName()), this.getClass().getTypeName());
         assertThrows(ClassNotFoundException.class, () -> Converter.CLASS.apply("foo.bar"));
         assertNotNull(Converter.CLASS.apply(AClassWithoutADefaultConstructor.class.getName()));
+    }
+
+    @Test
+    void testClassDoesNotInitialize() throws Exception {
+        final Class<?> cls = Converter.CLASS.apply(AClassWithAStaticInitializer.class.getName());
+        assertFalse(classInitializerRan);
+        assertEquals(AClassWithAStaticInitializer.class, cls);
+        cls.getConstructor().newInstance();
+        assertTrue(classInitializerRan);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -58,8 +58,23 @@ public class ConverterTests {
         }
     }
 
+    // Marker type a caller might validate a resolved Class against before touching it.
+    public interface Plugin {
+    }
+
+    // A Plugin whose static initializer has an observable side effect.
+    public static class PluginImpl implements Plugin {
+
+        static {
+            pluginInitializerRan = true;
+        }
+    }
+
     // Set by the static initializer of AClassWithAStaticInitializer; readable without initializing that class.
     private static boolean classInitializerRan;
+
+    // Set by the static initializer of PluginImpl; readable without initializing that class.
+    private static boolean pluginInitializerRan;
 
     private static Stream<Arguments> numberTestParameters() {
         final List<Arguments> lst = new ArrayList<>();
@@ -92,6 +107,18 @@ public class ConverterTests {
         assertEquals(AClassWithAStaticInitializer.class, cls);
         cls.getConstructor().newInstance();
         assertTrue(classInitializerRan);
+    }
+
+    @Test
+    void testClassValidatedBeforeInitialization() throws Exception {
+        // The caller pattern this enables: resolve the option, gate it with isAssignableFrom, then instantiate.
+        // The assignability check must not run the class's static initializer; only newInstance() should.
+        final Class<?> cls = Converter.CLASS.apply(PluginImpl.class.getName());
+        assertTrue(Plugin.class.isAssignableFrom(cls));
+        assertFalse(pluginInitializerRan);
+        final Object instance = cls.getConstructor().newInstance();
+        assertTrue(instance instanceof Plugin);
+        assertTrue(pluginInitializerRan);
     }
 
     @Test


### PR DESCRIPTION
`Converter.CLASS` was `Class::forName`, the single-argument overload, which initializes the class it resolves. Any option declared with type `Class` reaches it, so `-c some.Klass` runs that class's static initializer during parsing, before the application has looked at the returned `Class` object at all. Resolving a name should not execute code.

The three-argument overload with `initialize` set to `false` gives the same defining class loader and the same `ClassNotFoundException` contract, and defers initialization to first real use. `Converter.OBJECT` is unaffected because `getConstructor().newInstance()` initializes anyway.

Reachable through `PatternOptionBuilder` pattern `+`, `TypeHandler.createClass`, and `CommandLine.getParsedOptionValue`; the new test fails on master and passes with the change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
