### PR TITLE
Copy the Option before applying property values in handleProperties

### DIFF
--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -518,16 +518,17 @@ public class DefaultParser implements CommandLineParser {
             if (!cmd.hasOption(option) && !selected) {
                 // get the value from the properties
                 final String value = properties.getProperty(option);
-
-                if (opt.hasArg()) {
-                    if (opt.isValuesEmpty()) {
-                        opt.processValue(stripLeadingAndTrailingQuotesDefaultOff(value));
+                // the Options belong to the caller and outlive this parse, so hold the value on a copy
+                final Option copy = (Option) opt.clone();
+                if (copy.hasArg()) {
+                    if (copy.isValuesEmpty()) {
+                        copy.processValue(stripLeadingAndTrailingQuotesDefaultOff(value));
                     }
                 } else if (!("yes".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value) || "1".equalsIgnoreCase(value))) {
                     // if the value is not yes, true or 1 then don't add the option to the CommandLine
                     continue;
                 }
-                handleOption(opt);
+                handleOption(copy);
                 currentOption = null;
             }
         }

--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -518,15 +518,14 @@ public class DefaultParser implements CommandLineParser {
             if (!cmd.hasOption(option) && !selected) {
                 // get the value from the properties
                 final String value = properties.getProperty(option);
-                // the Options belong to the caller and outlive this parse, so hold the value on a copy
-                final Option copy = (Option) opt.clone();
-                if (copy.hasArg()) {
-                    if (copy.isValuesEmpty()) {
-                        copy.processValue(stripLeadingAndTrailingQuotesDefaultOff(value));
-                    }
-                } else if (!("yes".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value) || "1".equalsIgnoreCase(value))) {
+                if (!opt.hasArg() && !("yes".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value) || "1".equalsIgnoreCase(value))) {
                     // if the value is not yes, true or 1 then don't add the option to the CommandLine
                     continue;
+                }
+                // the Options belong to the caller and outlive this parse, so hold the value on a copy
+                final Option copy = (Option) opt.clone();
+                if (copy.hasArg() && copy.isValuesEmpty()) {
+                    copy.processValue(stripLeadingAndTrailingQuotesDefaultOff(value));
                 }
                 handleOption(copy);
                 currentOption = null;

--- a/src/main/java/org/apache/commons/cli/Parser.java
+++ b/src/main/java/org/apache/commons/cli/Parser.java
@@ -284,10 +284,12 @@ public abstract class Parser implements CommandLineParser {
             if (!cmd.hasOption(option) && !selected) {
                 // get the value from the properties instance
                 final String value = properties.getProperty(option);
-                if (opt.hasArg()) {
-                    if (opt.isValuesEmpty()) {
+                // the Options belong to the caller and outlive this parse, so hold the value on a copy
+                final Option copy = (Option) opt.clone();
+                if (copy.hasArg()) {
+                    if (copy.isValuesEmpty()) {
                         try {
-                            opt.processValue(value);
+                            copy.processValue(value);
                         } catch (final RuntimeException exp) { // NOPMD
                             // if we cannot add the value don't worry about it
                         }
@@ -297,8 +299,8 @@ public abstract class Parser implements CommandLineParser {
                     // option to the CommandLine
                     continue;
                 }
-                cmd.addOption(opt);
-                updateRequiredOptions(opt);
+                cmd.addOption(copy);
+                updateRequiredOptions(copy);
             }
         }
     }

--- a/src/main/java/org/apache/commons/cli/Parser.java
+++ b/src/main/java/org/apache/commons/cli/Parser.java
@@ -284,20 +284,19 @@ public abstract class Parser implements CommandLineParser {
             if (!cmd.hasOption(option) && !selected) {
                 // get the value from the properties instance
                 final String value = properties.getProperty(option);
-                // the Options belong to the caller and outlive this parse, so hold the value on a copy
-                final Option copy = (Option) opt.clone();
-                if (copy.hasArg()) {
-                    if (copy.isValuesEmpty()) {
-                        try {
-                            copy.processValue(value);
-                        } catch (final RuntimeException exp) { // NOPMD
-                            // if we cannot add the value don't worry about it
-                        }
-                    }
-                } else if (!("yes".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value) || "1".equalsIgnoreCase(value))) {
+                if (!opt.hasArg() && !("yes".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value) || "1".equalsIgnoreCase(value))) {
                     // if the value is not yes, true or 1 then don't add the
                     // option to the CommandLine
                     continue;
+                }
+                // the Options belong to the caller and outlive this parse, so hold the value on a copy
+                final Option copy = (Option) opt.clone();
+                if (copy.hasArg() && copy.isValuesEmpty()) {
+                    try {
+                        copy.processValue(value);
+                    } catch (final RuntimeException exp) { // NOPMD
+                        // if we cannot add the value don't worry about it
+                    }
                 }
                 cmd.addOption(copy);
                 updateRequiredOptions(copy);

--- a/src/test/java/org/apache/commons/cli/AbstractParserTestCase.java
+++ b/src/test/java/org/apache/commons/cli/AbstractParserTestCase.java
@@ -617,6 +617,26 @@ public abstract class AbstractParserTestCase {
     }
 
     @Test
+    void testPropertyOptionReusedOptions() throws Exception {
+        final Options options = new Options();
+        options.addOption(Option.builder("k").hasArg().get());
+
+        final Properties first = new Properties();
+        first.setProperty("k", "one");
+        final CommandLine firstCmd = parse(parser, options, null, first);
+        assertEquals("one", firstCmd.getOptionValue('k'));
+
+        final Properties second = new Properties();
+        second.setProperty("k", "two");
+        final CommandLine secondCmd = parse(parser, options, null, second);
+        assertEquals("two", secondCmd.getOptionValue('k'));
+
+        // the second parse must not reach back into the first result, and the Options must be left alone
+        assertEquals("one", firstCmd.getOptionValue('k'));
+        assertNull(options.getOption("k").getValue());
+    }
+
+    @Test
     void testPropertyOptionSingularValue() throws Exception {
         final Options options = new Options();
         options.addOption(OptionBuilder.hasOptionalArgs(2).withLongOpt("hide").create());


### PR DESCRIPTION
`DefaultParser.handleProperties` calls `processValue` on the `Option` instance owned by the caller's `Options` rather than on a copy, so a value that arrives through the defaults `Properties` is written into the shared `Option` and stays there after the parse. Reuse that same `Options` for a second parse and the `isValuesEmpty` guard silently serves the first parse's value instead of the second one's, the value remains readable through `options.getOption(...)`, and two threads parsing at once write the same values list. `Parser.processProperties` has the same write-through and also puts the shared `Option` on the `CommandLine`, so a later parse rewrites what an earlier `CommandLine` returns.

Both property paths now clone before storing the value, which is what the argv paths already do in `handleOption` and `processArgs`. The new test in `AbstractParserTestCase` fails for `DefaultParser`, `BasicParser`, `GnuParser` and `PosixParser` without the change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
