### PR TITLE
Reject an empty option name in getMatchingOptions

### DIFF
--- a/src/main/java/org/apache/commons/cli/Options.java
+++ b/src/main/java/org/apache/commons/cli/Options.java
@@ -219,6 +219,10 @@ public class Options implements Serializable {
     public List<String> getMatchingOptions(final String opt) {
         final String clean = Util.stripLeadingHyphens(opt);
         final List<String> matchingOpts = new ArrayList<>();
+        // an empty name is not a partial name, it would match every long option
+        if (Util.isEmpty(clean)) {
+            return matchingOpts;
+        }
         // for a perfect match return the single option only
         if (longOpts.containsKey(clean)) {
             return Collections.singletonList(clean);

--- a/src/main/java/org/apache/commons/cli/Options.java
+++ b/src/main/java/org/apache/commons/cli/Options.java
@@ -212,14 +212,14 @@ public class Options implements Serializable {
     /**
      * Gets the options with a long name starting with the name specified.
      *
-     * @param opt The partial name of the option.
-     * @return The options matching the partial name specified, or an empty list if none matches.
+     * @param opt The partial name of the option, or {@code null}.
+     * @return The options matching the partial name specified, or an empty list if none matches or the name is null or empty.
      * @since 1.3
      */
     public List<String> getMatchingOptions(final String opt) {
         final String clean = Util.stripLeadingHyphens(opt);
         final List<String> matchingOpts = new ArrayList<>();
-        // an empty name is not a partial name, it would match every long option
+        // a null or empty name is not a partial name; empty would match every long option
         if (Util.isEmpty(clean)) {
             return matchingOpts;
         }

--- a/src/main/java/org/apache/commons/cli/Options.java
+++ b/src/main/java/org/apache/commons/cli/Options.java
@@ -212,7 +212,7 @@ public class Options implements Serializable {
     /**
      * Gets the options with a long name starting with the name specified.
      *
-     * @param opt The partial name of the option, or {@code null}.
+     * @param opt The partial name of the option, may be {@code null}.
      * @return The options matching the partial name specified, or an empty list if none matches or the name is null or empty.
      * @since 1.3
      */

--- a/src/test/java/org/apache/commons/cli/OptionsTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionsTest.java
@@ -183,6 +183,19 @@ class OptionsTest {
     }
 
     @Test
+    void testGetMatchingOptsEmptyName() throws Exception {
+        final Options options = new Options();
+        options.addOption(Option.builder("c").longOpt("config-file").hasArg().get());
+        assertTrue(options.getMatchingOptions("").isEmpty());
+        assertTrue(options.getMatchingOptions("-").isEmpty());
+        assertTrue(options.getMatchingOptions("--").isEmpty());
+        // "--=value" names no option, so it must not bind a value to config-file
+        for (final CommandLineParser parser : new CommandLineParser[] { new DefaultParser(), new PosixParser() }) {
+            assertThrows(UnrecognizedOptionException.class, () -> parser.parse(options, new String[] { "--=/etc/shadow" }));
+        }
+    }
+
+    @Test
     void testGetOptionsGroups() {
         final Options options = new Options();
 

--- a/src/test/java/org/apache/commons/cli/OptionsTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionsTest.java
@@ -186,6 +186,7 @@ class OptionsTest {
     void testGetMatchingOptsEmptyName() throws Exception {
         final Options options = new Options();
         options.addOption(Option.builder("c").longOpt("config-file").hasArg().get());
+        assertTrue(options.getMatchingOptions(null).isEmpty());
         assertTrue(options.getMatchingOptions("").isEmpty());
         assertTrue(options.getMatchingOptions("-").isEmpty());
         assertTrue(options.getMatchingOptions("--").isEmpty());


### PR DESCRIPTION
Repro: `--=/etc/shadow` parsed against an `Options` that holds a single long option `--config-file`. Both `DefaultParser` and `PosixParser` return a `CommandLine` with `config-file` set to `/etc/shadow`, and an empty argument list. Nothing on the command line named that option.

Cause: `getMatchingOptions` strips the hyphens off `--`, leaving an empty name, and `longOpt.startsWith("")` holds for every entry, so an empty name matches the entire long option table. `handleLongOptionWithEqual` splits `--=V` into opt `--` and value `V`, sees one match, and binds. `PosixParser.flatten` reaches the same list from its own `--` branch. With more than one long option defined the same token raises `AmbiguousOptionException` naming all of them rather than rejecting it, and `isLongOption` classifies `-=` as an option, so `-=` cannot be passed as a value to the option before it.

Fix: an empty name is not a partial name, so return no matches for it. Both parsers share that one lookup, and `--=V` now reaches `handleUnknownToken` like any other token that names no option.

What this costs an application is the assumption that a long option is only set when its name appears in argv. A launcher or wrapper that inspects argv and refuses, say, `--config-file` sees `--=...` name nothing, while the parser behind it binds the value anyway.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
