### PR TITLE
Reject trailing text after the date in Converter.DATE

### DIFF
--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -82,15 +83,24 @@ public interface Converter<T, E extends Exception> {
         final SimpleDateFormat format = new SimpleDateFormat(pattern);
         // reject out-of-range fields (for example "Feb 30") instead of silently rolling them over.
         format.setLenient(false);
-        try {
-            return format.parse(s);
-        } catch (final java.text.ParseException e) {
+        // SimpleDateFormat.parse(String) stops at the first character it cannot use and ignores any
+        // trailing text, so "<valid date> garbage" would be accepted. Parse from an explicit position
+        // and reject the value unless the whole string is consumed.
+        final ParsePosition pos = new ParsePosition(0);
+        Date date = format.parse(s, pos);
+        if (date == null || pos.getIndex() != s.length()) {
             // Date.toString() always emits English month/day names, so fall back to Locale.ENGLISH
             // when the default locale rejects the documented format.
             final SimpleDateFormat englishFormat = new SimpleDateFormat(pattern, Locale.ENGLISH);
             englishFormat.setLenient(false);
-            return englishFormat.parse(s);
+            final ParsePosition englishPos = new ParsePosition(0);
+            date = englishFormat.parse(s, englishPos);
+            if (date == null || englishPos.getIndex() != s.length()) {
+                final int errorIndex = englishPos.getErrorIndex() >= 0 ? englishPos.getErrorIndex() : englishPos.getIndex();
+                throw new java.text.ParseException(String.format("Unparseable date: \"%s\"", s), errorIndex);
+            }
         }
+        return date;
     };
 
     /**

--- a/src/main/java/org/apache/commons/cli/Converter.java
+++ b/src/main/java/org/apache/commons/cli/Converter.java
@@ -88,17 +88,19 @@ public interface Converter<T, E extends Exception> {
         // and reject the value unless the whole string is consumed.
         final ParsePosition pos = new ParsePosition(0);
         Date date = format.parse(s, pos);
-        if (date == null || pos.getIndex() != s.length()) {
+        if (date == null) {
             // Date.toString() always emits English month/day names, so fall back to Locale.ENGLISH
-            // when the default locale rejects the documented format.
+            // when the default locale rejects the documented format. Only retry when the default
+            // locale matched nothing; a partial match is a trailing-text failure, handled below.
             final SimpleDateFormat englishFormat = new SimpleDateFormat(pattern, Locale.ENGLISH);
             englishFormat.setLenient(false);
-            final ParsePosition englishPos = new ParsePosition(0);
-            date = englishFormat.parse(s, englishPos);
-            if (date == null || englishPos.getIndex() != s.length()) {
-                final int errorIndex = englishPos.getErrorIndex() >= 0 ? englishPos.getErrorIndex() : englishPos.getIndex();
-                throw new java.text.ParseException(String.format("Unparseable date: \"%s\"", s), errorIndex);
-            }
+            pos.setIndex(0);
+            pos.setErrorIndex(-1);
+            date = englishFormat.parse(s, pos);
+        }
+        if (date == null || pos.getIndex() != s.length()) {
+            final int errorIndex = pos.getErrorIndex() >= 0 ? pos.getErrorIndex() : pos.getIndex();
+            throw new java.text.ParseException(String.format("Unparseable date: \"%s\"", s), errorIndex);
         }
         return date;
     };

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -87,6 +87,13 @@ public class ConverterTests {
     }
 
     @Test
+    void testDateRejectsTrailingText() throws Exception {
+        final Date expected = new Date(1023400137000L);
+        final String formatted = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy").format(expected);
+        assertThrows(java.text.ParseException.class, () -> Converter.DATE.apply(formatted + " trailing"));
+    }
+
+    @Test
     @DefaultLocale(language = "de", country = "DE")
     void testDateLocaleDe() throws Exception {
         final Date expected = new Date(1023400137000L);

--- a/src/test/java/org/apache/commons/cli/ConverterTests.java
+++ b/src/test/java/org/apache/commons/cli/ConverterTests.java
@@ -95,6 +95,17 @@ public class ConverterTests {
 
     @Test
     @DefaultLocale(language = "de", country = "DE")
+    void testDateRejectsTrailingTextLocaleDe() throws Exception {
+        // Trailing text must be rejected even when a non-English default locale parses the date, and
+        // the reported error position should point past the parsed date rather than at index 0.
+        final Date expected = new Date(1023400137000L);
+        final String formatted = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy").format(expected);
+        final java.text.ParseException e = assertThrows(java.text.ParseException.class, () -> Converter.DATE.apply(formatted + " trailing"));
+        assertEquals(formatted.length(), e.getErrorOffset());
+    }
+
+    @Test
+    @DefaultLocale(language = "de", country = "DE")
     void testDateLocaleDe() throws Exception {
         final Date expected = new Date(1023400137000L);
         final String formatted = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy").format(expected);


### PR DESCRIPTION
`Converter.DATE` parses with `SimpleDateFormat.parse(String)`, which stops at the first character it cannot use and ignores whatever follows, so a `Date`-typed option value like `Fri Jun 07 03:18:57 IST 2002 rm -rf /` returns a valid `Date` and the trailing text is dropped. That defeats the `setLenient(false)` strictness added in #430. Parse from an explicit `ParsePosition` and reject the value unless the whole string is consumed, keeping the `Locale.ENGLISH` fallback.