### PR TITLE
Reject unpaired UTF-16 surrogates in Character type converter

### DIFF
--- a/src/main/java/org/apache/commons/cli/TypeHandler.java
+++ b/src/main/java/org/apache/commons/cli/TypeHandler.java
@@ -236,6 +236,9 @@ public class TypeHandler {
                 if (!Character.isBmpCodePoint(codePoint)) {
                     throw new IllegalArgumentException("Code point U+" + Integer.toHexString(codePoint) + " does not fit in a char");
                 }
+                if (Character.isSurrogate((char) codePoint)) {
+                    throw new IllegalArgumentException("Code point U+" + Integer.toHexString(codePoint) + " is an unpaired UTF-16 surrogate");
+                }
                 return (char) codePoint;
             }
             return s.charAt(0);

--- a/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
+++ b/src/test/java/org/apache/commons/cli/TypeHandlerTest.java
@@ -135,6 +135,8 @@ class TypeHandlerTest {
         list.add(Arguments.of("5.5", Character.class, '5'));
         list.add(Arguments.of("\\u0124", Character.class, Character.toChars(0x0124)[0]));
         list.add(Arguments.of("\\u1F600", Character.class, ParseException.class));
+        list.add(Arguments.of("\\uD800", Character.class, ParseException.class));
+        list.add(Arguments.of("\\uDFFF", Character.class, ParseException.class));
 
         list.add(Arguments.of("just-a-string", Double.class, ParseException.class));
         list.add(Arguments.of("5", Double.class, 5d));


### PR DESCRIPTION
The Character type converter reads a \uXXXX escape straight from an argv value, and the non-BMP guard added in #425 still lets an unpaired UTF-16 surrogate (U+D800 to U+DFFF) through because isBmpCodePoint is true for surrogates, so \uD800 casts to an ill-formed char instead of being rejected the way an astral code point is. Add an isSurrogate check right after the BMP check so the converter throws for a lone surrogate too. Test cases for \uD800 and \uDFFF fail on master and pass with the fix.